### PR TITLE
(#61) fix: 모임 목록 화면 cell 업데이트 문제 해결

### DIFF
--- a/WithBuddy/Presentation/Common/ListCollectionViewCell.swift
+++ b/WithBuddy/Presentation/Common/ListCollectionViewCell.swift
@@ -28,8 +28,8 @@ final class ListCollectionViewCell: UICollectionViewCell {
     
     override func prepareForReuse() {
         super.prepareForReuse()
-        self.buddyStackView = UIStackView()
-        self.typeStackView = UIStackView()
+        self.buddyStackView.arrangedSubviews.forEach { $0.removeFromSuperview() }
+        self.typeStackView.arrangedSubviews.forEach { $0.removeFromSuperview() }
     }
     
     func update(date: Date, buddyImageList: [String], typeList: [String]) {


### PR DESCRIPTION
## 💡 이슈 번호

#61 

<br/>

## 📚 작업 내역

- 모임 목록 화면의 cell이 제대로 업데이트 되지 않던 문제를 해결하였습니다. 

