### PR TITLE
(#108) 네비게이션 바 완료버튼 삭제

### DIFF
--- a/WithBuddy/Presentation/BuddyManage/BuddyManageViewController.swift
+++ b/WithBuddy/Presentation/BuddyManage/BuddyManageViewController.swift
@@ -27,7 +27,6 @@ class BuddyManageViewController: UIViewController {
         super.viewDidLoad()
         self.configure()
         self.bind()
-        self.navigationItem.rightBarButtonItem = UIBarButtonItem(title: "완료", style: .done, target: self, action: #selector(self.popView))
     }
     
     private func bind() {
@@ -96,10 +95,6 @@ class BuddyManageViewController: UIViewController {
             self.buddyCollectionView.trailingAnchor.constraint(equalTo: self.searchView.trailingAnchor),
             self.buddyCollectionView.bottomAnchor.constraint(equalTo: self.view.safeAreaLayoutGuide.bottomAnchor, constant: -20)
         ])
-    }
-    
-    @objc func popView() {
-        self.navigationController?.popViewController(animated: true)
     }
     
     @objc private func newBuddyButtonTouched(_ sender: UIButton) {


### PR DESCRIPTION
## 💡 이슈 번호

#108

<br/>

## 📚 작업 내역

- 네비게이션 바 완료버튼 삭제

