### PR TITLE
(#133) 통계 화면 버블이 깜박이는 문제 해결 및 기록 없을 때 첫번째 버블 히든 처리

### DIFF
--- a/WithBuddy/Presentation/Chart/View/BubbleChartView.swift
+++ b/WithBuddy/Presentation/Chart/View/BubbleChartView.swift
@@ -59,12 +59,11 @@ final class BubbleChartView: UIView {
     }
     
     func resetBubbles() {
-        let size = CGSize(width: CGFloat.zero, height: CGFloat.zero)
-        self.firstBubbleImageView.frame.size = size
-        self.secondBubbleImageView.frame.size = size
-        self.thirdBubbleImageView.frame.size = size
-        self.fourthBubbleImageView.frame.size = size
-        self.fifthBubbleImageView.frame.size = size
+        self.firstBubbleImageView.frame.size = CGSize.zero
+        self.secondBubbleImageView.frame.size = CGSize.zero
+        self.thirdBubbleImageView.frame.size = CGSize.zero
+        self.fourthBubbleImageView.frame.size = CGSize.zero
+        self.fifthBubbleImageView.frame.size = CGSize.zero
     }
     
     private func update(imageView: UIImageView, face: String?, count: Int?, xValue: CGFloat, yValue: CGFloat) {

--- a/WithBuddy/Presentation/Chart/View/BubbleChartView.swift
+++ b/WithBuddy/Presentation/Chart/View/BubbleChartView.swift
@@ -147,8 +147,9 @@ final class BubbleChartView: UIView {
     }
     
     private func configureFirstBubble() {
-        self.firstBubbleImageView.translatesAutoresizingMaskIntoConstraints = false
         self.firstBubbleImageView.image = UIImage(named: "FacePurple1")
+        self.firstBubbleImageView.isHidden =  true
+        self.firstBubbleImageView.translatesAutoresizingMaskIntoConstraints = false
         NSLayoutConstraint.activate([
             self.firstBubbleImageView.centerXAnchor.constraint(equalTo: self.whiteView.centerXAnchor),
             self.firstBubbleImageView.centerYAnchor.constraint(equalTo: self.whiteView.centerYAnchor),

--- a/WithBuddy/Presentation/Chart/View/BubbleChartView.swift
+++ b/WithBuddy/Presentation/Chart/View/BubbleChartView.swift
@@ -58,6 +58,15 @@ final class BubbleChartView: UIView {
         self.update(imageView: self.fifthBubbleImageView, face: fifth?.0.face, count: fifth?.1, xValue: constant, yValue: -constant)
     }
     
+    func resetBubbles() {
+        let size = CGSize(width: CGFloat.zero, height: CGFloat.zero)
+        self.firstBubbleImageView.frame.size = size
+        self.secondBubbleImageView.frame.size = size
+        self.thirdBubbleImageView.frame.size = size
+        self.fourthBubbleImageView.frame.size = size
+        self.fifthBubbleImageView.frame.size = size
+    }
+    
     private func update(imageView: UIImageView, face: String?, count: Int?, xValue: CGFloat, yValue: CGFloat) {
         if let face = face, let count = count, let maxCount = self.maxCount {
             imageView.image = UIImage(named: face)

--- a/WithBuddy/Presentation/Chart/View/ChartViewController.swift
+++ b/WithBuddy/Presentation/Chart/View/ChartViewController.swift
@@ -29,6 +29,10 @@ final class ChartViewController: UIViewController {
         self.viewModel.fetch()
     }
     
+    override func viewDidDisappear(_ animated: Bool) {
+        self.bubbleChartView.resetBubbles()
+    }
+    
     private func configure() {
         self.configureScrollView()
         self.configureContentView()

--- a/WithBuddy/Presentation/Chart/ViewModel/ChartViewModel.swift
+++ b/WithBuddy/Presentation/Chart/ViewModel/ChartViewModel.swift
@@ -60,7 +60,7 @@ final class ChartViewModel {
         }
         let index = min(5, sortedBuddyList.count - 1)
         if Int.zero <= index {
-            self.buddyRank = Array(sortedBuddyList[...index].map{ ($0.key, $0.value) })
+            self.buddyRank = Array(sortedBuddyList[...index].filter{ $0.value != Int.zero }.map{ ($0.key, $0.value) })
         }
     }
     


### PR DESCRIPTION
## 💡 이슈 번호

#133

<br/>

## 📚 작업 내역

- 버블 깜박이는 문제 해결
- 버블에 0개짜리 데이터가 표시되던 문제 해결
- 데이터 없을 때 첫번째 버블이 표시되던 문제 해결

