### PR TITLE
(#131) 달력 셀에 애니메이션 적용, CoreData Buddy Update, Delete 구현

### DIFF
--- a/WithBuddy/Data/PersistentStorage/CoreDataManager.swift
+++ b/WithBuddy/Data/PersistentStorage/CoreDataManager.swift
@@ -11,6 +11,7 @@ protocol CoreDataManagable {
     
     @discardableResult func insertGathering(_ gathering: Gathering) -> Bool
     @discardableResult func insertBuddy(_ buddy: Buddy) -> Bool
+    @discardableResult func updateBuddy(_ buddy: Buddy) -> Bool
     func fetchAllBuddy() -> [BuddyEntity]
     func fetchAllGathering() -> [GatheringEntity]
     func fetchBuddy(name: String) -> [BuddyEntity]
@@ -113,6 +114,24 @@ extension CoreDataManager: CoreDataManagable {
     func insertGathering(_ gathering: Gathering) -> Bool {
         let gatheringEntity = GatheringEntity(context: self.context, gathering: gathering)
         gatheringEntity.addToBuddyList(NSSet(array: self.fetchBuddyEntity(of: gathering.buddyList)))
+        
+        do {
+            try self.context.save()
+            return true
+        } catch {
+            print(error.localizedDescription)
+            return false
+        }
+    }
+    
+    @discardableResult
+    func updateBuddy(_ buddy: Buddy) -> Bool {
+        let request = BuddyEntity.fetchRequest()
+        request.predicate = NSPredicate(format: "id == %@", buddy.id as CVarArg )
+        
+        guard let buddyEntity = self.fetch(request: request).first else { return false }
+        buddyEntity.name = buddy.name
+        buddyEntity.face = buddy.face
         
         do {
             try self.context.save()

--- a/WithBuddy/Data/PersistentStorage/CoreDataManager.swift
+++ b/WithBuddy/Data/PersistentStorage/CoreDataManager.swift
@@ -12,6 +12,7 @@ protocol CoreDataManagable {
     @discardableResult func insertGathering(_ gathering: Gathering) -> Bool
     @discardableResult func insertBuddy(_ buddy: Buddy) -> Bool
     @discardableResult func updateBuddy(_ buddy: Buddy) -> Bool
+    @discardableResult func deleteBuddy(_ buddy: Buddy) -> Bool
     func fetchAllBuddy() -> [BuddyEntity]
     func fetchAllGathering() -> [GatheringEntity]
     func fetchBuddy(name: String) -> [BuddyEntity]
@@ -132,6 +133,23 @@ extension CoreDataManager: CoreDataManagable {
         guard let buddyEntity = self.fetch(request: request).first else { return false }
         buddyEntity.name = buddy.name
         buddyEntity.face = buddy.face
+        
+        do {
+            try self.context.save()
+            return true
+        } catch {
+            print(error.localizedDescription)
+            return false
+        }
+    }
+    
+    @discardableResult
+    func deleteBuddy(_ buddy: Buddy) -> Bool {
+        let request = BuddyEntity.fetchRequest()
+        request.predicate = NSPredicate(format: "id == %@", buddy.id as CVarArg )
+        
+        guard let buddyEntity = self.fetch(request: request).first else { return false }
+        context.delete(buddyEntity)
         
         do {
             try self.context.save()

--- a/WithBuddy/Domain/UseCases/BuddyUseCase.swift
+++ b/WithBuddy/Domain/UseCases/BuddyUseCase.swift
@@ -38,6 +38,10 @@ final class BuddyUseCase {
         self.coreDataManager.updateBuddy(buddy)
     }
     
+    func deleteBuddy(_ buddy: Buddy) {
+        self.coreDataManager.deleteBuddy(buddy)
+    }
+    
     private func makeRandomFace() -> String {
         let colorList = [FaceColor.blue, FaceColor.green, FaceColor.pink, FaceColor.purple, FaceColor.red, FaceColor.yellow]
         guard let color = colorList.randomElement() else { return "FacePurple1" }

--- a/WithBuddy/Domain/UseCases/BuddyUseCase.swift
+++ b/WithBuddy/Domain/UseCases/BuddyUseCase.swift
@@ -34,6 +34,10 @@ final class BuddyUseCase {
                      face: self.makeRandomFace())
     }
     
+    func updateBuddy(_ buddy: Buddy) {
+        self.coreDataManager.updateBuddy(buddy)
+    }
+    
     private func makeRandomFace() -> String {
         let colorList = [FaceColor.blue, FaceColor.green, FaceColor.pink, FaceColor.purple, FaceColor.red, FaceColor.yellow]
         guard let color = colorList.randomElement() else { return "FacePurple1" }

--- a/WithBuddy/Presentation/BuddyChoice/BuddyChoiceViewModel.swift
+++ b/WithBuddy/Presentation/BuddyChoice/BuddyChoiceViewModel.swift
@@ -33,6 +33,7 @@ class BuddyChoiceViewModel {
     private var buddyUseCase = BuddyUseCase(coreDataManager: CoreDataManager.shared)
     
     func buddyDidADeleted(in idx: Int) {
+        self.buddyUseCase.deleteBuddy(storedBuddyList[idx])
         self.storedBuddyList.remove(at: idx)
     }
     

--- a/WithBuddy/Presentation/Calendar/View/CalendarViewController.swift
+++ b/WithBuddy/Presentation/Calendar/View/CalendarViewController.swift
@@ -136,6 +136,10 @@ extension CalendarViewController: UICollectionViewDataSource, UICollectionViewDe
     }
     
     func collectionView(_ collectionView: UICollectionView, didSelectItemAt indexPath: IndexPath) {
+        guard let cell = collectionView.cellForItem(at: indexPath) as? WBCalendarViewCell,
+              !self.calendarViewModel.totalFaces[indexPath.item].isEmpty else { return }
+        cell.animateButtonTap(duration: 0.4, scale: 0.9)
+        
         let calendarDetailViewController = CalendarDetailViewController(
             calendarDetailViewModel: CalendarDetailViewModel(
                 selectedDate: self.calendarViewModel.findDate(index: indexPath.item)


### PR DESCRIPTION
## 💡 이슈 번호

#131

<br/>

## 📚 작업 내역

- 달력 셀에 애니메이션 적용
- CoreData Buddy Update, Delete 구현

