### PR TITLE
(#179) 모임 등록시 다음날에 푸시 알람 가도록 적용

### DIFF
--- a/WithBuddy/Application/AppDelegate.swift
+++ b/WithBuddy/Application/AppDelegate.swift
@@ -8,14 +8,16 @@
 import UIKit
 
 @main
-class AppDelegate: UIResponder, UIApplicationDelegate {
+class AppDelegate: UIResponder, UIApplicationDelegate, UNUserNotificationCenterDelegate {
 
     func application(_ application: UIApplication, supportedInterfaceOrientationsFor window: UIWindow?) -> UIInterfaceOrientationMask {
        return UIInterfaceOrientationMask.portrait
    }
     
     func application(_ application: UIApplication, didFinishLaunchingWithOptions launchOptions: [UIApplication.LaunchOptionsKey: Any]?) -> Bool {
-        // Override point for customization after application launch.
+        let center = UNUserNotificationCenter.current()
+        center.delegate = self
+        
         return true
     }
 
@@ -30,6 +32,10 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
         // Called when the user discards a scene session.
         // If any sessions were discarded while the application was not running, this will be called shortly after application:didFinishLaunchingWithOptions.
         // Use this method to release any resources that were specific to the discarded scenes, as they will not return.
+    }
+    
+    func userNotificationCenter(_ center: UNUserNotificationCenter, willPresent notification: UNNotification, withCompletionHandler completionHandler: @escaping (UNNotificationPresentationOptions) -> Void) {
+        completionHandler([.alert, .sound])
     }
 }
 

--- a/WithBuddy/Presentation/Register/View/RegisterViewController.swift
+++ b/WithBuddy/Presentation/Register/View/RegisterViewController.swift
@@ -168,7 +168,7 @@ class RegisterViewController: UIViewController {
         content.title = "위드버디"
         let firstBuddyName = gathering.buddyList.first?.name ?? ""
         let buddyCountString = gathering.buddyList.count == 1 ? "" : "외 \(gathering.buddyList.count-1)명"
-        content.body = "전날 \(firstBuddyName)님 \(buddyCountString)과의 만남은 어떠셨나요?"
+        content.body = "어제 \(firstBuddyName)님 \(buddyCountString)과의 만남은 어떠셨나요?"
         
         let dateComponents = Calendar.current.dateComponents([.year, .month, .day, .hour, .minute], from: nextDay)
         let trigger = UNCalendarNotificationTrigger(

--- a/WithBuddy/Presentation/Register/ViewModel/RegisterViewModel.swift
+++ b/WithBuddy/Presentation/Register/ViewModel/RegisterViewModel.swift
@@ -29,7 +29,7 @@ class RegisterViewModel {
         return self.purposeList.filter( { $0.check })
     }
     private(set) var addBuddySignal = PassthroughSubject<[Buddy], Never>()
-    private(set) var registerDoneSignal = PassthroughSubject<Void, Never>()
+    private(set) var registerDoneSignal = PassthroughSubject<Gathering, Never>()
     private(set) var registerFailSignal = PassthroughSubject<RegisterError, Never>()
     
     @Published private(set) var purposeList: [CheckableInfo] = PurposeCategory.allCases.map({ CheckableInfo(description: "\($0)", check: false) })
@@ -88,8 +88,17 @@ class RegisterViewModel {
             guard let date = date else {
                 return
             }
-            self.gatheringUseCase.insertGathering(Gathering(id: UUID(), date: date, place: self.place, purpose: self.checkedPurposeList.map{ $0.description }, buddyList: self.buddyList, memo: self.memo, picture: self.pictures))
-            self.registerDoneSignal.send()
+            let gathering = Gathering(
+                id: UUID(),
+                date: date,
+                place: self.place,
+                purpose: self.checkedPurposeList.map{ $0.description },
+                buddyList: self.buddyList,
+                memo: self.memo,
+                picture: self.pictures
+            )
+            self.gatheringUseCase.insertGathering(gathering)
+            self.registerDoneSignal.send(gathering)
         }
     }
     


### PR DESCRIPTION
## 💡 이슈 번호

#179 

<br/>

## 📚 작업 내역

- 모임 등록시 다음날에 푸시 알람 가도록 적용
- 아직 클릭시 해당 모임으로 넘어가는 건 적용 못했어요
- 모임 수정했을때도 적용해야 하는데 그것도 못했어요..

