### PR TITLE
(#236) 사용자 이름이 길 경우 통계 화면의 글자가 잘리는 문제 해결

### DIFF
--- a/WithBuddy/Presentation/Chart/View/BubbleChartView.swift
+++ b/WithBuddy/Presentation/Chart/View/BubbleChartView.swift
@@ -9,8 +9,7 @@ import UIKit
 
 final class BubbleChartView: UIView {
     
-    private let nameLabel = PurpleTitleLabel()
-    private let titleLabel = BlackTitleLabel()
+    private let titleLabel = PurpleTitleLabel()
     private let whiteView = WhiteView()
     private let firstBubbleImageView = UIImageView()
     private let secondBubbleImageView = UIImageView()
@@ -19,7 +18,7 @@ final class BubbleChartView: UIView {
     private let fifthBubbleImageView = UIImageView()
     private let defaultView = DefaultView()
     
-    private let maxLength = CGFloat(130)
+    private let maxLength = CGFloat.chartBubbleMaxLength
     private var maxCount: Int?
     
     override init(frame: CGRect) {
@@ -30,10 +29,6 @@ final class BubbleChartView: UIView {
     required init?(coder: NSCoder) {
         super.init(coder: coder)
         self.configure()
-    }
-    
-    func update(name: String) {
-        self.nameLabel.text = name
     }
     
     func update(list: [(Buddy, Int)]) {
@@ -97,7 +92,6 @@ final class BubbleChartView: UIView {
     }
     
     private func configure() {
-        self.configureNameLabel()
         self.configureTitleLabel()
         self.configureWhiteView()
         self.configureChart()
@@ -106,22 +100,13 @@ final class BubbleChartView: UIView {
         self.configureDefaultView()
     }
     
-    private func configureNameLabel() {
-        self.addSubview(self.nameLabel)
-        self.nameLabel.translatesAutoresizingMaskIntoConstraints = false
-        NSLayoutConstraint.activate([
-            self.nameLabel.leadingAnchor.constraint(equalTo: self.leadingAnchor),
-            self.nameLabel.topAnchor.constraint(equalTo: self.topAnchor)
-        ])
-    }
-    
     private func configureTitleLabel() {
         self.addSubview(self.titleLabel)
-        self.titleLabel.text = "님이 많이 만난 버디"
+        self.titleLabel.text = .bubbleChartTitle
         self.titleLabel.translatesAutoresizingMaskIntoConstraints = false
         NSLayoutConstraint.activate([
-            self.titleLabel.leadingAnchor.constraint(equalTo: self.nameLabel.trailingAnchor),
-            self.titleLabel.centerYAnchor.constraint(equalTo: self.nameLabel.centerYAnchor)
+            self.titleLabel.leadingAnchor.constraint(equalTo: self.leadingAnchor),
+            self.titleLabel.topAnchor.constraint(equalTo: self.topAnchor)
         ])
     }
     
@@ -129,10 +114,10 @@ final class BubbleChartView: UIView {
         self.addSubview(self.whiteView)
         self.whiteView.translatesAutoresizingMaskIntoConstraints = false
         NSLayoutConstraint.activate([
-            self.whiteView.leadingAnchor.constraint(equalTo: self.nameLabel.leadingAnchor),
-            self.whiteView.topAnchor.constraint(equalTo: self.nameLabel.bottomAnchor, constant: 10),
+            self.whiteView.leadingAnchor.constraint(equalTo: self.titleLabel.leadingAnchor),
+            self.whiteView.topAnchor.constraint(equalTo: self.titleLabel.bottomAnchor, constant: .innerPartInset),
             self.whiteView.trailingAnchor.constraint(equalTo: self.trailingAnchor),
-            self.whiteView.heightAnchor.constraint(equalToConstant: 250),
+            self.whiteView.heightAnchor.constraint(equalToConstant: .bubbleChartHeight),
             self.whiteView.bottomAnchor.constraint(equalTo: self.bottomAnchor)
         ])
     }
@@ -167,7 +152,7 @@ final class BubbleChartView: UIView {
     
     private func configureBubble(imageView: UIImageView) {
         imageView.isHidden = true
-        imageView.frame.size = CGSize(width: 0, height: 0)
+        imageView.frame.size = CGSize.zero
     }
     
     private func configureDefaultView() {
@@ -176,8 +161,8 @@ final class BubbleChartView: UIView {
         NSLayoutConstraint.activate([
             self.defaultView.centerXAnchor.constraint(equalTo: self.whiteView.centerXAnchor),
             self.defaultView.centerYAnchor.constraint(equalTo: self.whiteView.centerYAnchor),
-            self.defaultView.widthAnchor.constraint(equalToConstant: 200),
-            self.defaultView.heightAnchor.constraint(equalToConstant: 200)
+            self.defaultView.widthAnchor.constraint(equalToConstant: .chartDefaultViewLength),
+            self.defaultView.heightAnchor.constraint(equalToConstant: .chartDefaultViewLength)
         ])
     }
 

--- a/WithBuddy/Presentation/Chart/View/ChartViewController.swift
+++ b/WithBuddy/Presentation/Chart/View/ChartViewController.swift
@@ -42,16 +42,6 @@ final class ChartViewController: UIViewController {
     }
     
     private func bind() {
-        self.viewModel.$name
-            .receive(on: DispatchQueue.main)
-            .sink(receiveValue: { [weak self] name in
-                guard let name = name else { return }
-                self?.bubbleChartView.update(name: name)
-                self?.purposeChartView.update(name: name)
-                self?.latestOldChartView.update(name: name)
-            })
-            .store(in: &self.cancellables)
-                    
         self.viewModel.$buddyRank
             .receive(on: DispatchQueue.main)
             .sink { [weak self] list in
@@ -108,9 +98,9 @@ final class ChartViewController: UIViewController {
         self.contentView.addSubview(self.bubbleChartView)
         self.bubbleChartView.translatesAutoresizingMaskIntoConstraints = false
         NSLayoutConstraint.activate([
-            self.bubbleChartView.leadingAnchor.constraint(equalTo: self.contentView.leadingAnchor, constant: 20),
-            self.bubbleChartView.topAnchor.constraint(equalTo: self.contentView.topAnchor, constant: 20),
-            self.bubbleChartView.trailingAnchor.constraint(equalTo: self.contentView.trailingAnchor, constant: -20)
+            self.bubbleChartView.leadingAnchor.constraint(equalTo: self.contentView.leadingAnchor, constant: .plusInset),
+            self.bubbleChartView.topAnchor.constraint(equalTo: self.contentView.topAnchor, constant: .plusInset),
+            self.bubbleChartView.trailingAnchor.constraint(equalTo: self.contentView.trailingAnchor, constant: .minusInset)
         ])
     }
     
@@ -119,7 +109,7 @@ final class ChartViewController: UIViewController {
         self.purposeChartView.translatesAutoresizingMaskIntoConstraints = false
         NSLayoutConstraint.activate([
             self.purposeChartView.leadingAnchor.constraint(equalTo: self.bubbleChartView.leadingAnchor),
-            self.purposeChartView.topAnchor.constraint(equalTo: self.bubbleChartView.bottomAnchor, constant: 20),
+            self.purposeChartView.topAnchor.constraint(equalTo: self.bubbleChartView.bottomAnchor, constant: .plusInset),
             self.purposeChartView.trailingAnchor.constraint(equalTo: self.bubbleChartView.trailingAnchor)
         ])
     }
@@ -129,16 +119,10 @@ final class ChartViewController: UIViewController {
         self.latestOldChartView.translatesAutoresizingMaskIntoConstraints = false
         NSLayoutConstraint.activate([
             self.latestOldChartView.leadingAnchor.constraint(equalTo: self.bubbleChartView.leadingAnchor),
-            self.latestOldChartView.topAnchor.constraint(equalTo: self.purposeChartView.bottomAnchor, constant: 20),
+            self.latestOldChartView.topAnchor.constraint(equalTo: self.purposeChartView.bottomAnchor, constant: .plusInset),
             self.latestOldChartView.trailingAnchor.constraint(equalTo: self.bubbleChartView.trailingAnchor),
             self.latestOldChartView.bottomAnchor.constraint(equalTo: self.contentView.bottomAnchor)
         ])
-    }
-    
-    private func update(name: String) {
-        self.bubbleChartView.update(name: name)
-        self.purposeChartView.update(name: name)
-        self.latestOldChartView.update(name: name)
     }
     
     private func update(buddyList: [(Buddy, Int)]?) {

--- a/WithBuddy/Presentation/Chart/View/LatestOldChartView.swift
+++ b/WithBuddy/Presentation/Chart/View/LatestOldChartView.swift
@@ -9,8 +9,7 @@ import UIKit
 
 final class LatestOldChartView: UIView {
     
-    private let nameLabel = PurpleTitleLabel()
-    private let titleLabel = BlackTitleLabel()
+    private let titleLabel = PurpleTitleLabel()
     private let whiteView = WhiteView()
     private let stackView = UIStackView()
     private let latestView = LatestOldView()
@@ -25,10 +24,6 @@ final class LatestOldChartView: UIView {
     required init?(coder: NSCoder) {
         super.init(coder: coder)
         self.configure()
-    }
-    
-    func update(name: String) {
-        self.nameLabel.text = name
     }
     
     func update(latestName: String, face: String) {
@@ -52,30 +47,20 @@ final class LatestOldChartView: UIView {
     }
     
     private func configure() {
-        self.configureNameLabel()
-        self.configureWhiteView()
         self.configureTitleLabel()
+        self.configureWhiteView()
         self.configureStackView()
         self.configureChartView()
         self.configureDefaultView()
     }
     
-    private func configureNameLabel() {
-        self.addSubview(self.nameLabel)
-        self.nameLabel.translatesAutoresizingMaskIntoConstraints = false
-        NSLayoutConstraint.activate([
-            self.nameLabel.leadingAnchor.constraint(equalTo: self.leadingAnchor),
-            self.nameLabel.topAnchor.constraint(equalTo: self.topAnchor)
-        ])
-    }
-    
     private func configureTitleLabel() {
         self.addSubview(self.titleLabel)
-        self.titleLabel.text = "님이 가장 최근/오래전에 만난 버디"
+        self.titleLabel.text = .latestOldChartTitle
         self.titleLabel.translatesAutoresizingMaskIntoConstraints = false
         NSLayoutConstraint.activate([
-            self.titleLabel.leadingAnchor.constraint(equalTo: self.nameLabel.trailingAnchor),
-            self.titleLabel.centerYAnchor.constraint(equalTo: self.nameLabel.centerYAnchor)
+            self.titleLabel.leadingAnchor.constraint(equalTo: self.leadingAnchor),
+            self.titleLabel.topAnchor.constraint(equalTo: self.topAnchor)
         ])
     }
     
@@ -83,17 +68,17 @@ final class LatestOldChartView: UIView {
         self.addSubview(self.whiteView)
         self.whiteView.translatesAutoresizingMaskIntoConstraints = false
         NSLayoutConstraint.activate([
-            self.whiteView.leadingAnchor.constraint(equalTo: self.nameLabel.leadingAnchor),
-            self.whiteView.topAnchor.constraint(equalTo: self.nameLabel.bottomAnchor, constant: 10),
+            self.whiteView.leadingAnchor.constraint(equalTo: self.titleLabel.leadingAnchor),
+            self.whiteView.topAnchor.constraint(equalTo: self.titleLabel.bottomAnchor, constant: .innerPartInset),
             self.whiteView.trailingAnchor.constraint(equalTo: self.trailingAnchor),
-            self.whiteView.heightAnchor.constraint(equalToConstant: 180),
+            self.whiteView.heightAnchor.constraint(equalToConstant: .latestOldChartHeight),
             self.whiteView.bottomAnchor.constraint(equalTo: self.bottomAnchor)
         ])
     }
     
     private func configureStackView() {
         self.whiteView.addSubview(self.stackView)
-        self.stackView.spacing = 30
+        self.stackView.spacing = .latestOldSpacing
         self.stackView.alignment = .center
         self.stackView.isHidden = true
         self.stackView.translatesAutoresizingMaskIntoConstraints = false
@@ -107,8 +92,8 @@ final class LatestOldChartView: UIView {
     private func configureChartView() {
         self.stackView.addArrangedSubview(self.latestView)
         self.stackView.addArrangedSubview(self.oldView)
-        self.latestView.update(description: "가장 최근에 만난 버디는")
-        self.oldView.update(description: "만난지 가장 오래된 버디는")
+        self.latestView.update(description: .latestDescription)
+        self.oldView.update(description: .oldDescription)
     }
     
     private func configureDefaultView() {
@@ -117,8 +102,8 @@ final class LatestOldChartView: UIView {
         NSLayoutConstraint.activate([
             self.defaultView.centerXAnchor.constraint(equalTo: self.whiteView.centerXAnchor),
             self.defaultView.centerYAnchor.constraint(equalTo: self.whiteView.centerYAnchor),
-            self.defaultView.widthAnchor.constraint(equalToConstant: 200),
-            self.defaultView.heightAnchor.constraint(equalToConstant: 150)
+            self.defaultView.widthAnchor.constraint(equalToConstant: .chartDefaultViewLength),
+            self.defaultView.heightAnchor.constraint(equalToConstant: .chartDefaultViewHeight)
         ])
     }
     

--- a/WithBuddy/Presentation/Chart/View/LatestOldView.swift
+++ b/WithBuddy/Presentation/Chart/View/LatestOldView.swift
@@ -7,11 +7,10 @@
 
 import UIKit
 
-class LatestOldView: UIView {
+final class LatestOldView: UIView {
 
     private let imageView = UIImageView()
     private let firstLabel = UILabel()
-    private let stackView = UIStackView()
     private let nameLabel = UILabel()
     private let secondLabel = UILabel()
 
@@ -30,28 +29,27 @@ class LatestOldView: UIView {
     }
     
     func update(name: String, face: String) {
-        let maxLenght = 10
-        self.nameLabel.text = String(name.prefix(maxLenght))
+        self.nameLabel.text = String(name)
         self.imageView.image = UIImage(named: face)
     }
     
     private func configure() {
         self.configureImageView()
         self.configureFirstLabel()
-        self.configureStackView()
-        self.configureStackLabel()
+        self.configureNameLabel()
+        self.configureSecondLabel()
     }
     
     private func configureImageView() {
         self.addSubview(self.imageView)
-        self.imageView.image = UIImage(systemName: "photo")
+        self.imageView.image = .defaultFaceImage
         self.imageView.translatesAutoresizingMaskIntoConstraints = false
         NSLayoutConstraint.activate([
             self.imageView.leadingAnchor.constraint(equalTo: self.leadingAnchor),
             self.imageView.topAnchor.constraint(equalTo: self.topAnchor),
             self.imageView.trailingAnchor.constraint(equalTo: self.trailingAnchor),
-            self.imageView.widthAnchor.constraint(equalToConstant: 130),
-            self.imageView.heightAnchor.constraint(equalToConstant: 130)
+            self.imageView.widthAnchor.constraint(equalToConstant: .chartBubbleMaxLength),
+            self.imageView.heightAnchor.constraint(equalToConstant: .chartBubbleMaxLength)
         ])
     }
     
@@ -59,7 +57,6 @@ class LatestOldView: UIView {
         self.addSubview(self.firstLabel)
         self.firstLabel.font = .systemFont(ofSize: .chartLabelSize)
         self.firstLabel.textAlignment = .center
-        self.firstLabel.text = ""
         self.firstLabel.textColor = .systemGray
         self.firstLabel.translatesAutoresizingMaskIntoConstraints = false
         NSLayoutConstraint.activate([
@@ -69,25 +66,27 @@ class LatestOldView: UIView {
         ])
     }
     
-    private func configureStackView() {
-        self.addSubview(self.stackView)
-        self.stackView.alignment = .center
-        self.stackView.translatesAutoresizingMaskIntoConstraints = false
+    private func configureNameLabel() {
+        self.addSubview(self.nameLabel)
+        self.nameLabel.font = .boldSystemFont(ofSize: .chartLabelSize)
+        self.nameLabel.translatesAutoresizingMaskIntoConstraints = false
         NSLayoutConstraint.activate([
-            self.stackView.topAnchor.constraint(equalTo: self.firstLabel.bottomAnchor),
-            self.stackView.centerXAnchor.constraint(equalTo: self.firstLabel.centerXAnchor),
-            self.stackView.bottomAnchor.constraint(equalTo: self.bottomAnchor)
+            self.nameLabel.topAnchor.constraint(equalTo: self.firstLabel.bottomAnchor),
+            self.nameLabel.centerXAnchor.constraint(equalTo: self.firstLabel.centerXAnchor)
         ])
     }
     
-    private func configureStackLabel() {
-        self.stackView.addArrangedSubview(self.nameLabel)
-        self.stackView.addArrangedSubview(self.secondLabel)
-        self.nameLabel.text = "위드버디"
-        self.secondLabel.text = "님이에요!"
-        self.nameLabel.font = .boldSystemFont(ofSize: .chartLabelSize)
+    private func configureSecondLabel() {
+        self.addSubview(self.secondLabel)
+        self.secondLabel.text = .latestOldDescription
         self.secondLabel.font = .systemFont(ofSize: .chartLabelSize)
         self.secondLabel.textColor = .systemGray
+        self.secondLabel.translatesAutoresizingMaskIntoConstraints = false
+        NSLayoutConstraint.activate([
+            self.secondLabel.topAnchor.constraint(equalTo: self.nameLabel.bottomAnchor),
+            self.secondLabel.centerXAnchor.constraint(equalTo: self.nameLabel.centerXAnchor),
+            self.secondLabel.bottomAnchor.constraint(equalTo: self.bottomAnchor)
+        ])
     }
 
 }

--- a/WithBuddy/Presentation/Chart/View/PurposeChartView.swift
+++ b/WithBuddy/Presentation/Chart/View/PurposeChartView.swift
@@ -9,8 +9,7 @@ import UIKit
 
 final class PurposeChartView: UIView {
     
-    private let nameLabel = PurpleTitleLabel()
-    private let titleLabel = BlackTitleLabel()
+    private let titleLabel = PurpleTitleLabel()
     private let whiteView = WhiteView()
     private let stackView = UIStackView()
     private let firstPurposeView = PurposeView()
@@ -26,10 +25,6 @@ final class PurposeChartView: UIView {
     required init?(coder: NSCoder) {
         super.init(coder: coder)
         self.configure()
-    }
-    
-    func update(name: String) {
-        self.nameLabel.text = name
     }
     
     func update(list: [(String, String)]) {
@@ -59,21 +54,11 @@ final class PurposeChartView: UIView {
     }
     
     private func configure() {
-        self.configureNameLabel()
-        self.configureWhiteView()
         self.configureTitleLabel()
+        self.configureWhiteView()
         self.configureStackView()
         self.configurePurposeView()
         self.configureDefaultPurpose()
-    }
-    
-    private func configureNameLabel() {
-        self.addSubview(self.nameLabel)
-        self.nameLabel.translatesAutoresizingMaskIntoConstraints = false
-        NSLayoutConstraint.activate([
-            self.nameLabel.leadingAnchor.constraint(equalTo: self.leadingAnchor),
-            self.nameLabel.topAnchor.constraint(equalTo: self.topAnchor)
-        ])
     }
     
     private func configureTitleLabel() {
@@ -81,8 +66,8 @@ final class PurposeChartView: UIView {
         self.titleLabel.text = .purposeChartTitle
         self.titleLabel.translatesAutoresizingMaskIntoConstraints = false
         NSLayoutConstraint.activate([
-            self.titleLabel.leadingAnchor.constraint(equalTo: self.nameLabel.trailingAnchor),
-            self.titleLabel.centerYAnchor.constraint(equalTo: self.nameLabel.centerYAnchor)
+            self.titleLabel.leadingAnchor.constraint(equalTo: self.leadingAnchor),
+            self.titleLabel.topAnchor.constraint(equalTo: self.topAnchor)
         ])
     }
     
@@ -90,10 +75,10 @@ final class PurposeChartView: UIView {
         self.addSubview(self.whiteView)
         self.whiteView.translatesAutoresizingMaskIntoConstraints = false
         NSLayoutConstraint.activate([
-            self.whiteView.leadingAnchor.constraint(equalTo: self.nameLabel.leadingAnchor),
-            self.whiteView.topAnchor.constraint(equalTo: self.nameLabel.bottomAnchor, constant: .innerPartInset),
+            self.whiteView.leadingAnchor.constraint(equalTo: self.titleLabel.leadingAnchor),
+            self.whiteView.topAnchor.constraint(equalTo: self.titleLabel.bottomAnchor, constant: .innerPartInset),
             self.whiteView.trailingAnchor.constraint(equalTo: self.trailingAnchor),
-            self.whiteView.heightAnchor.constraint(equalToConstant: .purposeWhiteViewHeight),
+            self.whiteView.heightAnchor.constraint(equalToConstant: .purposeChartHeight),
             self.whiteView.bottomAnchor.constraint(equalTo: self.bottomAnchor)
         ])
     }

--- a/WithBuddy/Presentation/Chart/ViewModel/ChartViewModel.swift
+++ b/WithBuddy/Presentation/Chart/ViewModel/ChartViewModel.swift
@@ -10,7 +10,6 @@ import Combine
 
 final class ChartViewModel {
     
-    @Published private(set) var name: String?
     @Published private(set) var buddyRank: [(Buddy, Int)] = []
     @Published private(set) var purposeRank: [(String, String)] = []
     @Published private(set) var latestBuddy: Buddy?
@@ -36,17 +35,11 @@ final class ChartViewModel {
     }
     
     func fetch() {
-        self.fetchName()
         self.fetchGatheringAndBuddy()
         self.fetchBuddyRank()
         self.fetchPurposeRank()
         self.fetchLatestBuddy()
         self.fetchOldBuddy()
-    }
-    
-    private func fetchName() {
-        guard let buddy = self.userUseCase.fetchUser() else { return }
-        self.name = buddy.name
     }
     
     private func fetchGatheringAndBuddy() {

--- a/WithBuddy/Presentation/Common/Extension/CGFloat+Extension.swift
+++ b/WithBuddy/Presentation/Common/Extension/CGFloat+Extension.swift
@@ -32,7 +32,14 @@ extension CGFloat {
     
     static let buttonCornerRadius = CGFloat(5)
     
+    static let chartBubbleMaxLength = CGFloat(130)
+    static let chartDefaultViewLength = CGFloat(200)
+    static let chartDefaultViewHeight = CGFloat(150)
+    static let bubbleChartHeight = CGFloat(250)
+    static let purposeChartHeight = CGFloat(100)
+    static let latestOldChartHeight = CGFloat(180)
+    static let latestOldSpacing = CGFloat(30)
     static let purposeSpacing = CGFloat(4)
     static let purposeImageSize = CGFloat(65)
-    static let purposeWhiteViewHeight = CGFloat(100)
+    
 }

--- a/WithBuddy/Presentation/Common/Extension/CGFloat+Extension.swift
+++ b/WithBuddy/Presentation/Common/Extension/CGFloat+Extension.swift
@@ -37,7 +37,7 @@ extension CGFloat {
     static let chartDefaultViewHeight = CGFloat(150)
     static let bubbleChartHeight = CGFloat(250)
     static let purposeChartHeight = CGFloat(100)
-    static let latestOldChartHeight = CGFloat(180)
+    static let latestOldChartHeight = CGFloat(200)
     static let latestOldSpacing = CGFloat(30)
     static let purposeSpacing = CGFloat(4)
     static let purposeImageSize = CGFloat(65)

--- a/WithBuddy/Presentation/Common/Extension/String+Extension.swift
+++ b/WithBuddy/Presentation/Common/Extension/String+Extension.swift
@@ -21,6 +21,7 @@ extension String {
     static let latestOldChartTitle = "가장 최근/오래전에 만난 버디"
     static let latestDescription = "가장 최근에 만난 버디는"
     static let oldDescription = "만난지 가장 오래된 버디는"
+    static let latestOldDescription = "님이에요!"
     static let defaultHobby = "DefaultHobby"
     static let defaultStudy = "DefaultStudy"
     static let defaultMeal = "DefaultMeal"

--- a/WithBuddy/Presentation/Common/Extension/String+Extension.swift
+++ b/WithBuddy/Presentation/Common/Extension/String+Extension.swift
@@ -16,7 +16,11 @@ extension String {
     
     // MARK: Chart
     
-    static let purposeChartTitle = "님의 만남 목적"
+    static let bubbleChartTitle = "많이 만난 버디"
+    static let purposeChartTitle = "만남 목적"
+    static let latestOldChartTitle = "가장 최근/오래전에 만난 버디"
+    static let latestDescription = "가장 최근에 만난 버디는"
+    static let oldDescription = "만난지 가장 오래된 버디는"
     static let defaultHobby = "DefaultHobby"
     static let defaultStudy = "DefaultStudy"
     static let defaultMeal = "DefaultMeal"


### PR DESCRIPTION
## 💡 이슈 번호

#236 

<br/>

## 📚 작업 내역

- 통계화면의 사용자 이름 삭제
- 가장 최근/오래전에 만난 버디 label 표시 방식을 2줄에서 3줄로 변경

