### PR TITLE
(#179) 푸시 알람 터치시 해당 모임 상세화면으로 이동하도록 적용

### DIFF
--- a/WithBuddy/Application/AppDelegate.swift
+++ b/WithBuddy/Application/AppDelegate.swift
@@ -37,5 +37,21 @@ class AppDelegate: UIResponder, UIApplicationDelegate, UNUserNotificationCenterD
     func userNotificationCenter(_ center: UNUserNotificationCenter, willPresent notification: UNNotification, withCompletionHandler completionHandler: @escaping (UNNotificationPresentationOptions) -> Void) {
         completionHandler([.alert, .sound])
     }
+    
+    func userNotificationCenter(_ center: UNUserNotificationCenter, didReceive response: UNNotificationResponse, withCompletionHandler completionHandler: @escaping () -> Void) {
+        guard let window = (UIApplication.shared.connectedScenes.first?.delegate as? SceneDelegate)?.window,
+              let id = UUID(uuidString: response.notification.request.identifier) else { return }
+        
+        let tabBarController = TabBarViewController()
+        tabBarController.selectedIndex = 3
+        let navigationController = UINavigationController(rootViewController: tabBarController)
+        let gatheringDetailViewController = GatheringDetailViewController()
+        gatheringDetailViewController.id = id
+        navigationController.pushViewController(gatheringDetailViewController, animated: true)
+        window.rootViewController = navigationController
+        window.makeKeyAndVisible()
+        
+        completionHandler()
+    }
 }
 

--- a/WithBuddy/Data/PersistentStorage/CoreDataManager.swift
+++ b/WithBuddy/Data/PersistentStorage/CoreDataManager.swift
@@ -25,6 +25,7 @@ protocol CoreDataManagable {
     func deleteGathering(_ gatheringId: UUID)
     func fetchPurpose() -> AnyPublisher<[PurposeEntity], Never>
     func deleteAllGathering() -> AnyPublisher<Void, CoreDataManager.CoreDataError>
+    func fetchGathering(id: UUID) -> GatheringEntity?
     
 }
 
@@ -32,9 +33,13 @@ final class CoreDataManager {
     
     enum CoreDataError: LocalizedError {
         case deleteFail
+        case noGathering
         
         var errorDescription: String? {
-            return "삭제에 실패하셨습니다."
+            switch self {
+            case .deleteFail: return "삭제에 실패하셨습니다."
+            case .noGathering: return "해당 모임을 찾을 수 없습니다."
+            }
         }
     }
     
@@ -264,6 +269,18 @@ extension CoreDataManager: CoreDataManagable {
                 promise(.failure(.deleteFail))
             }
         }.eraseToAnyPublisher()
+    }
+    
+    func fetchGathering(id: UUID) -> GatheringEntity? {
+        let request = GatheringEntity.fetchRequest()
+        request.predicate = NSPredicate(
+            format: "%K == %@",
+            #keyPath(GatheringEntity.id),
+            id as CVarArg
+        )
+        
+        return self.fetch(request: request).first
+        
     }
     
 }

--- a/WithBuddy/Data/PersistentStorage/CoreDataManager.swift
+++ b/WithBuddy/Data/PersistentStorage/CoreDataManager.swift
@@ -280,7 +280,6 @@ extension CoreDataManager: CoreDataManagable {
         )
         
         return self.fetch(request: request).first
-        
     }
     
 }

--- a/WithBuddy/Domain/UseCases/GatheringUseCase.swift
+++ b/WithBuddy/Domain/UseCases/GatheringUseCase.swift
@@ -20,6 +20,11 @@ final class GatheringUseCase {
         return self.coreDataManager.fetchAllGathering().map{ $0.toDomain() }
     }
     
+    func fetchGathering(id: UUID) -> Gathering? {
+        guard let gatheringEntity = self.coreDataManager.fetchGathering(id: id) else { return nil }
+        return gatheringEntity.toDomain()
+    }
+    
     func fetchGathering(including name: String) -> [Gathering] {
         return self.coreDataManager.fetchGathering(including: name).map{ $0.toDomain() }
     }

--- a/WithBuddy/Presentation/Calendar/View/CalendarViewController.swift
+++ b/WithBuddy/Presentation/Calendar/View/CalendarViewController.swift
@@ -179,7 +179,7 @@ extension CalendarViewController: GatheringListDelegate {
     
     func gatheringListTouched(_ gathering: Gathering) {
             let gatheringDetailViewController = GatheringDetailViewController()
-            gatheringDetailViewController.update(by: gathering)
+            gatheringDetailViewController.id = gathering.id
             self.navigationController?.pushViewController(gatheringDetailViewController, animated: true)
     }
     

--- a/WithBuddy/Presentation/GatheringDetail/View/GatheringDetailViewController.swift
+++ b/WithBuddy/Presentation/GatheringDetail/View/GatheringDetailViewController.swift
@@ -10,6 +10,7 @@ import Combine
 
 class GatheringDetailViewController: UIViewController {
     
+    var id: UUID?
     private lazy var scrollView = UIScrollView()
     private lazy var contentView = UIView()
     
@@ -60,8 +61,15 @@ class GatheringDetailViewController: UIViewController {
     }
 
     override func viewWillAppear(_ animated: Bool) {
+        super.viewWillAppear(animated)
         self.title = "모임 상세화면"
         self.navigationController?.navigationBar.titleTextAttributes = [.foregroundColor: UIColor.labelPurple as Any]
+    }
+    
+    override func viewDidAppear(_ animated: Bool) {
+        super.viewDidAppear(animated)
+        guard let id = self.id else { return }
+        self.gatheringDetailViewModel.viewDidAppear(with: id)
     }
     
     private func configure() {
@@ -88,7 +96,6 @@ class GatheringDetailViewController: UIViewController {
             .sink(receiveValue: { [weak self] gathering in
                 let gatheringEditViewController = GatheringEditViewController()
                 gatheringEditViewController.configure(by: gathering)
-                gatheringEditViewController.delegate = self
                 self?.navigationController?.navigationBar.topItem?.title = "Back"
                 self?.navigationController?.pushViewController(gatheringEditViewController, animated: true)
             })
@@ -101,13 +108,9 @@ class GatheringDetailViewController: UIViewController {
             .sink(receiveValue: { [weak self] gathering in
                 if let gathering = gathering {
                     self?.configure(by: gathering)
-                }
+                } 
             })
             .store(in: &self.cancellables)
-    }
-    
-    func update(by gathering: Gathering) {
-        self.gatheringDetailViewModel.didGatheringChanged(to: gathering)
     }
     
     func configure(by gathering: Gathering) {
@@ -460,14 +463,6 @@ class GatheringDetailViewController: UIViewController {
     
     @objc private func editGathering() {
         self.gatheringDetailViewModel.didEditButtonTouched()
-    }
-    
-}
-
-extension GatheringDetailViewController: GatheringEditDelegate {
-    
-    func didGatheringEdited(to gathering: Gathering) {
-        self.gatheringDetailViewModel.didGatheringChanged(to: gathering)
     }
     
 }

--- a/WithBuddy/Presentation/GatheringDetail/View/GatheringDetailViewController.swift
+++ b/WithBuddy/Presentation/GatheringDetail/View/GatheringDetailViewController.swift
@@ -108,7 +108,7 @@ class GatheringDetailViewController: UIViewController {
             .sink(receiveValue: { [weak self] gathering in
                 if let gathering = gathering {
                     self?.configure(by: gathering)
-                } 
+                }
             })
             .store(in: &self.cancellables)
     }

--- a/WithBuddy/Presentation/GatheringDetail/ViewModel/GatheringDetailViewModel.swift
+++ b/WithBuddy/Presentation/GatheringDetail/ViewModel/GatheringDetailViewModel.swift
@@ -12,10 +12,19 @@ class GatheringDetailViewModel {
     
     @Published private(set) var gathering: Gathering?
     private(set) var goEditSignal = PassthroughSubject<Gathering, Never>()
-    private let purposeUseCase = PurposeUseCase(coreDataManager: CoreDataManager.shared)
+    private let gatheringUseCase: GatheringUseCase
+    private let purposeUseCase: PurposeUseCase
     
-    func didGatheringChanged(to gathering: Gathering) {
-        self.gathering = gathering
+    init(
+        gatheringUseCase: GatheringUseCase = GatheringUseCase(coreDataManager: CoreDataManager.shared),
+        purposeUseCase: PurposeUseCase = PurposeUseCase(coreDataManager: CoreDataManager.shared)
+    ) {
+        self.gatheringUseCase = gatheringUseCase
+        self.purposeUseCase = purposeUseCase
+    }
+    
+    func viewDidAppear(with id: UUID) {
+        self.gathering = self.gatheringUseCase.fetchGathering(id: id)
     }
     
     func didEditButtonTouched() {

--- a/WithBuddy/Presentation/List/View/ListViewController.swift
+++ b/WithBuddy/Presentation/List/View/ListViewController.swift
@@ -151,7 +151,7 @@ extension ListViewController: UITableViewDelegate {
     func tableView(_ tableView: UITableView, didSelectRowAt indexPath: IndexPath) {
         tableView.deselectRow(at: indexPath, animated: true)
         let gatheringDetailViewController = GatheringDetailViewController()
-        gatheringDetailViewController.update(by: self.listViewModel[indexPath.item])
+        gatheringDetailViewController.id = self.listViewModel[indexPath.item].id
         self.navigationController?.pushViewController(gatheringDetailViewController, animated: true)
     }
     


### PR DESCRIPTION
## 💡 이슈 번호

#179 

<br/>

## 📚 작업 내역

-  푸시 알람 터치시 모임 상세화면으로 이동하도록 적용
- 모임 삭제시 알람도 삭제되도록 적용

