### PR TITLE
Buddy Custom, User Custom 분리

### DIFF
--- a/WithBuddy.xcodeproj/project.pbxproj
+++ b/WithBuddy.xcodeproj/project.pbxproj
@@ -72,6 +72,7 @@
 		BB8744532756911C0032E8DF /* BuddyCustomView.swift in Sources */ = {isa = PBXBuildFile; fileRef = BB8744522756911C0032E8DF /* BuddyCustomView.swift */; };
 		BB8744552756B39B0032E8DF /* ColorCollectionView.swift in Sources */ = {isa = PBXBuildFile; fileRef = BB8744542756B39B0032E8DF /* ColorCollectionView.swift */; };
 		BB8744572756B5430032E8DF /* FaceCollectionView.swift in Sources */ = {isa = PBXBuildFile; fileRef = BB8744562756B5430032E8DF /* FaceCollectionView.swift */; };
+		BB87445A275718490032E8DF /* UserCustomViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = BB874459275718490032E8DF /* UserCustomViewModel.swift */; };
 		BBF7FF2F272FB51400B71C97 /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = BBF7FF2E272FB51400B71C97 /* Assets.xcassets */; };
 		BBF7FF32272FB51400B71C97 /* LaunchScreen.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = BBF7FF30272FB51400B71C97 /* LaunchScreen.storyboard */; };
 		BBF7FF40272FB7B700B71C97 /* TabBarViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = BBF7FF3F272FB7B700B71C97 /* TabBarViewController.swift */; };
@@ -191,6 +192,7 @@
 		BB8744522756911C0032E8DF /* BuddyCustomView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BuddyCustomView.swift; sourceTree = "<group>"; };
 		BB8744542756B39B0032E8DF /* ColorCollectionView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ColorCollectionView.swift; sourceTree = "<group>"; };
 		BB8744562756B5430032E8DF /* FaceCollectionView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FaceCollectionView.swift; sourceTree = "<group>"; };
+		BB874459275718490032E8DF /* UserCustomViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UserCustomViewModel.swift; sourceTree = "<group>"; };
 		BBF7FF22272FB51000B71C97 /* WithBuddy.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = WithBuddy.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		BBF7FF25272FB51000B71C97 /* AppDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppDelegate.swift; sourceTree = "<group>"; };
 		BBF7FF27272FB51000B71C97 /* SceneDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SceneDelegate.swift; sourceTree = "<group>"; };
@@ -577,6 +579,7 @@
 			isa = PBXGroup;
 			children = (
 				BB87444F2756901C0032E8DF /* View */,
+				BB874458275718360032E8DF /* ViewModel */,
 			);
 			path = UserCustom;
 			sourceTree = "<group>";
@@ -587,6 +590,14 @@
 				BB874450275690800032E8DF /* UserCustomViewController.swift */,
 			);
 			path = View;
+			sourceTree = "<group>";
+		};
+		BB874458275718360032E8DF /* ViewModel */ = {
+			isa = PBXGroup;
+			children = (
+				BB874459275718490032E8DF /* UserCustomViewModel.swift */,
+			);
+			path = ViewModel;
 			sourceTree = "<group>";
 		};
 		BBF7FF19272FB51000B71C97 = {
@@ -921,6 +932,7 @@
 				85D262F4273CF211000190B8 /* PurposeView.swift in Sources */,
 				85D262EE273CE6DD000190B8 /* WhiteView.swift in Sources */,
 				F7E8AC3E273CD4E6005F8306 /* ImageTextCollectionViewCell.swift in Sources */,
+				BB87445A275718490032E8DF /* UserCustomViewModel.swift in Sources */,
 				85624745274F5DC70041E927 /* String+Extension.swift in Sources */,
 				85456A2E2754C697006AFFF2 /* BubbleDescriptionView.swift in Sources */,
 				BB8744552756B39B0032E8DF /* ColorCollectionView.swift in Sources */,

--- a/WithBuddy.xcodeproj/project.pbxproj
+++ b/WithBuddy.xcodeproj/project.pbxproj
@@ -69,6 +69,9 @@
 		BB2D25C2273B901600E7BF35 /* BuddyEntity+CoreDataClass.swift in Sources */ = {isa = PBXBuildFile; fileRef = BB2D25BE273B901600E7BF35 /* BuddyEntity+CoreDataClass.swift */; };
 		BB2D25C4273B901600E7BF35 /* GatheringEntity+CoreDataClass.swift in Sources */ = {isa = PBXBuildFile; fileRef = BB2D25C0273B901600E7BF35 /* GatheringEntity+CoreDataClass.swift */; };
 		BB874451275690800032E8DF /* UserCustomViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = BB874450275690800032E8DF /* UserCustomViewController.swift */; };
+		BB8744532756911C0032E8DF /* BuddyCustomView.swift in Sources */ = {isa = PBXBuildFile; fileRef = BB8744522756911C0032E8DF /* BuddyCustomView.swift */; };
+		BB8744552756B39B0032E8DF /* ColorCollectionView.swift in Sources */ = {isa = PBXBuildFile; fileRef = BB8744542756B39B0032E8DF /* ColorCollectionView.swift */; };
+		BB8744572756B5430032E8DF /* FaceCollectionView.swift in Sources */ = {isa = PBXBuildFile; fileRef = BB8744562756B5430032E8DF /* FaceCollectionView.swift */; };
 		BBF7FF2F272FB51400B71C97 /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = BBF7FF2E272FB51400B71C97 /* Assets.xcassets */; };
 		BBF7FF32272FB51400B71C97 /* LaunchScreen.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = BBF7FF30272FB51400B71C97 /* LaunchScreen.storyboard */; };
 		BBF7FF40272FB7B700B71C97 /* TabBarViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = BBF7FF3F272FB7B700B71C97 /* TabBarViewController.swift */; };
@@ -185,6 +188,9 @@
 		BB2D25BE273B901600E7BF35 /* BuddyEntity+CoreDataClass.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "BuddyEntity+CoreDataClass.swift"; sourceTree = "<group>"; };
 		BB2D25C0273B901600E7BF35 /* GatheringEntity+CoreDataClass.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "GatheringEntity+CoreDataClass.swift"; sourceTree = "<group>"; };
 		BB874450275690800032E8DF /* UserCustomViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UserCustomViewController.swift; sourceTree = "<group>"; };
+		BB8744522756911C0032E8DF /* BuddyCustomView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BuddyCustomView.swift; sourceTree = "<group>"; };
+		BB8744542756B39B0032E8DF /* ColorCollectionView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ColorCollectionView.swift; sourceTree = "<group>"; };
+		BB8744562756B5430032E8DF /* FaceCollectionView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FaceCollectionView.swift; sourceTree = "<group>"; };
 		BBF7FF22272FB51000B71C97 /* WithBuddy.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = WithBuddy.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		BBF7FF25272FB51000B71C97 /* AppDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppDelegate.swift; sourceTree = "<group>"; };
 		BBF7FF27272FB51000B71C97 /* SceneDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SceneDelegate.swift; sourceTree = "<group>"; };
@@ -254,6 +260,9 @@
 				8AD669202744F12300158E1A /* ImageCollectionViewCell.swift */,
 				BB2D2553273112EE00E7BF35 /* ImageTextCollectionViewCell.swift */,
 				BB2D25A6273B582500E7BF35 /* PictureCollectionViewCell.swift */,
+				BB8744522756911C0032E8DF /* BuddyCustomView.swift */,
+				BB8744542756B39B0032E8DF /* ColorCollectionView.swift */,
+				BB8744562756B5430032E8DF /* FaceCollectionView.swift */,
 			);
 			path = View;
 			sourceTree = "<group>";
@@ -908,11 +917,13 @@
 				8521BE3D2743C492000F3C05 /* CalendarViewModel.swift in Sources */,
 				F78F14962743A5C90034E740 /* BuddyManageViewController.swift in Sources */,
 				8521BE3C27437BC4000F3C05 /* UIView+Extension.swift in Sources */,
+				BB8744572756B5430032E8DF /* FaceCollectionView.swift in Sources */,
 				85D262F4273CF211000190B8 /* PurposeView.swift in Sources */,
 				85D262EE273CE6DD000190B8 /* WhiteView.swift in Sources */,
 				F7E8AC3E273CD4E6005F8306 /* ImageTextCollectionViewCell.swift in Sources */,
 				85624745274F5DC70041E927 /* String+Extension.swift in Sources */,
 				85456A2E2754C697006AFFF2 /* BubbleDescriptionView.swift in Sources */,
+				BB8744552756B39B0032E8DF /* ColorCollectionView.swift in Sources */,
 				85624748274F6B3B0041E927 /* UIImage+Extension.swift in Sources */,
 				F7E8AC3C273CD4E2005F8306 /* AppDelegate.swift in Sources */,
 				8AF3152927461EA600BDDF85 /* Face.swift in Sources */,
@@ -953,6 +964,7 @@
 				BB2D25C4273B901600E7BF35 /* GatheringEntity+CoreDataClass.swift in Sources */,
 				85D262EC273CDEBE000190B8 /* LatestOldChartView.swift in Sources */,
 				8AD6691F2744D94B00158E1A /* BuddyCustomViewModel.swift in Sources */,
+				BB8744532756911C0032E8DF /* BuddyCustomView.swift in Sources */,
 				85D262F8273D138E000190B8 /* DefaultView.swift in Sources */,
 				F7E8ABB42738133B005F8306 /* CalendarDetailViewController.swift in Sources */,
 				BB2D25A3273A550B00E7BF35 /* BuddyUseCase.swift in Sources */,

--- a/WithBuddy.xcodeproj/project.pbxproj
+++ b/WithBuddy.xcodeproj/project.pbxproj
@@ -68,6 +68,7 @@
 		BB2D25BD273B585200E7BF35 /* RegisterViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = BB2D25BC273B585200E7BF35 /* RegisterViewModel.swift */; };
 		BB2D25C2273B901600E7BF35 /* BuddyEntity+CoreDataClass.swift in Sources */ = {isa = PBXBuildFile; fileRef = BB2D25BE273B901600E7BF35 /* BuddyEntity+CoreDataClass.swift */; };
 		BB2D25C4273B901600E7BF35 /* GatheringEntity+CoreDataClass.swift in Sources */ = {isa = PBXBuildFile; fileRef = BB2D25C0273B901600E7BF35 /* GatheringEntity+CoreDataClass.swift */; };
+		BB874451275690800032E8DF /* UserCustomViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = BB874450275690800032E8DF /* UserCustomViewController.swift */; };
 		BBF7FF2F272FB51400B71C97 /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = BBF7FF2E272FB51400B71C97 /* Assets.xcassets */; };
 		BBF7FF32272FB51400B71C97 /* LaunchScreen.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = BBF7FF30272FB51400B71C97 /* LaunchScreen.storyboard */; };
 		BBF7FF40272FB7B700B71C97 /* TabBarViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = BBF7FF3F272FB7B700B71C97 /* TabBarViewController.swift */; };
@@ -183,6 +184,7 @@
 		BB2D25BC273B585200E7BF35 /* RegisterViewModel.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = RegisterViewModel.swift; sourceTree = "<group>"; };
 		BB2D25BE273B901600E7BF35 /* BuddyEntity+CoreDataClass.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "BuddyEntity+CoreDataClass.swift"; sourceTree = "<group>"; };
 		BB2D25C0273B901600E7BF35 /* GatheringEntity+CoreDataClass.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "GatheringEntity+CoreDataClass.swift"; sourceTree = "<group>"; };
+		BB874450275690800032E8DF /* UserCustomViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UserCustomViewController.swift; sourceTree = "<group>"; };
 		BBF7FF22272FB51000B71C97 /* WithBuddy.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = WithBuddy.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		BBF7FF25272FB51000B71C97 /* AppDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppDelegate.swift; sourceTree = "<group>"; };
 		BBF7FF27272FB51000B71C97 /* SceneDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SceneDelegate.swift; sourceTree = "<group>"; };
@@ -562,6 +564,22 @@
 			path = ViewModel;
 			sourceTree = "<group>";
 		};
+		BB87444E2756900B0032E8DF /* UserCustom */ = {
+			isa = PBXGroup;
+			children = (
+				BB87444F2756901C0032E8DF /* View */,
+			);
+			path = UserCustom;
+			sourceTree = "<group>";
+		};
+		BB87444F2756901C0032E8DF /* View */ = {
+			isa = PBXGroup;
+			children = (
+				BB874450275690800032E8DF /* UserCustomViewController.swift */,
+			);
+			path = View;
+			sourceTree = "<group>";
+		};
 		BBF7FF19272FB51000B71C97 = {
 			isa = PBXGroup;
 			children = (
@@ -611,6 +629,7 @@
 			children = (
 				BBF7FF41272FB95400B71C97 /* Common */,
 				8A397A28274B8A7C0060443C /* UserCreate */,
+				BB87444E2756900B0032E8DF /* UserCustom */,
 				85FA1D91272FEAE500825C64 /* Calendar */,
 				F7E8ABC2273BB7A6005F8306 /* Calendardetail */,
 				BB2D255B2731315900E7BF35 /* Chart */,
@@ -956,6 +975,7 @@
 				BB1936D3274B8F50007EF21A /* PurposeUseCase.swift in Sources */,
 				8562474A274F84F40041E927 /* UIColor+Extension.swift in Sources */,
 				BB2D25A5273A58A100E7BF35 /* GatheringUseCase.swift in Sources */,
+				BB874451275690800032E8DF /* UserCustomViewController.swift in Sources */,
 				F78EE745274CDEB000948960 /* BuddyImageView.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;

--- a/WithBuddy.xcodeproj/project.pbxproj
+++ b/WithBuddy.xcodeproj/project.pbxproj
@@ -73,6 +73,8 @@
 		BB8744552756B39B0032E8DF /* ColorCollectionView.swift in Sources */ = {isa = PBXBuildFile; fileRef = BB8744542756B39B0032E8DF /* ColorCollectionView.swift */; };
 		BB8744572756B5430032E8DF /* FaceCollectionView.swift in Sources */ = {isa = PBXBuildFile; fileRef = BB8744562756B5430032E8DF /* FaceCollectionView.swift */; };
 		BB87445A275718490032E8DF /* UserCustomViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = BB874459275718490032E8DF /* UserCustomViewModel.swift */; };
+		BB87445F27571FC10032E8DF /* UserEditViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = BB87445E27571FC10032E8DF /* UserEditViewController.swift */; };
+		BB87446127571FD00032E8DF /* UserEditViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = BB87446027571FD00032E8DF /* UserEditViewModel.swift */; };
 		BBF7FF2F272FB51400B71C97 /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = BBF7FF2E272FB51400B71C97 /* Assets.xcassets */; };
 		BBF7FF32272FB51400B71C97 /* LaunchScreen.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = BBF7FF30272FB51400B71C97 /* LaunchScreen.storyboard */; };
 		BBF7FF40272FB7B700B71C97 /* TabBarViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = BBF7FF3F272FB7B700B71C97 /* TabBarViewController.swift */; };
@@ -193,6 +195,8 @@
 		BB8744542756B39B0032E8DF /* ColorCollectionView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ColorCollectionView.swift; sourceTree = "<group>"; };
 		BB8744562756B5430032E8DF /* FaceCollectionView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FaceCollectionView.swift; sourceTree = "<group>"; };
 		BB874459275718490032E8DF /* UserCustomViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UserCustomViewModel.swift; sourceTree = "<group>"; };
+		BB87445E27571FC10032E8DF /* UserEditViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UserEditViewController.swift; sourceTree = "<group>"; };
+		BB87446027571FD00032E8DF /* UserEditViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UserEditViewModel.swift; sourceTree = "<group>"; };
 		BBF7FF22272FB51000B71C97 /* WithBuddy.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = WithBuddy.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		BBF7FF25272FB51000B71C97 /* AppDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppDelegate.swift; sourceTree = "<group>"; };
 		BBF7FF27272FB51000B71C97 /* SceneDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SceneDelegate.swift; sourceTree = "<group>"; };
@@ -600,6 +604,31 @@
 			path = ViewModel;
 			sourceTree = "<group>";
 		};
+		BB87445B27571F840032E8DF /* UserEdit */ = {
+			isa = PBXGroup;
+			children = (
+				BB87445C27571FA50032E8DF /* View */,
+				BB87445D27571FAB0032E8DF /* ViewModel */,
+			);
+			path = UserEdit;
+			sourceTree = "<group>";
+		};
+		BB87445C27571FA50032E8DF /* View */ = {
+			isa = PBXGroup;
+			children = (
+				BB87445E27571FC10032E8DF /* UserEditViewController.swift */,
+			);
+			path = View;
+			sourceTree = "<group>";
+		};
+		BB87445D27571FAB0032E8DF /* ViewModel */ = {
+			isa = PBXGroup;
+			children = (
+				BB87446027571FD00032E8DF /* UserEditViewModel.swift */,
+			);
+			path = ViewModel;
+			sourceTree = "<group>";
+		};
 		BBF7FF19272FB51000B71C97 = {
 			isa = PBXGroup;
 			children = (
@@ -661,6 +690,7 @@
 				F78F14942743A5B00034E740 /* BuddyManage */,
 				85FA1D97272FEBBB00825C64 /* List */,
 				BB2D255C2731315E00E7BF35 /* Setting */,
+				BB87445B27571F840032E8DF /* UserEdit */,
 			);
 			path = Presentation;
 			sourceTree = "<group>";
@@ -945,6 +975,7 @@
 				F7E8AC3B273CD4DC005F8306 /* FaceColor.swift in Sources */,
 				8A07DF6D2743C21B008F6E58 /* GatheringDetailViewModel.swift in Sources */,
 				BB0EF0DE2740FA15003B4B6F /* WBCalendarCollectionView.swift in Sources */,
+				BB87446127571FD00032E8DF /* UserEditViewModel.swift in Sources */,
 				F7E8AC2F273CB5F9005F8306 /* Gathering.swift in Sources */,
 				8560CCBA274B8E0F0076F500 /* PurpleLabel.swift in Sources */,
 				F7A7699B2732588500FF83EA /* WBCalendarView.swift in Sources */,
@@ -993,6 +1024,7 @@
 				BB2D25BD273B585200E7BF35 /* RegisterViewModel.swift in Sources */,
 				F78F149B2743C1CF0034E740 /* BuddyManageViewModel.swift in Sources */,
 				8A73D679273A61EC001D5184 /* BuddyChoiceViewController.swift in Sources */,
+				BB87445F27571FC10032E8DF /* UserEditViewController.swift in Sources */,
 				854AA7662733A37200663911 /* ListViewModel.swift in Sources */,
 				8A397A2C274B8AE80060443C /* UserCreateViewModel.swift in Sources */,
 				BB2D258F2739299A00E7BF35 /* CoreDataManager.swift in Sources */,

--- a/WithBuddy/Presentation/BuddyChoice/View/BuddyChoiceViewController.swift
+++ b/WithBuddy/Presentation/BuddyChoice/View/BuddyChoiceViewController.swift
@@ -31,6 +31,11 @@ final class BuddyChoiceViewController: UIViewController {
         self.navigationItem.rightBarButtonItem = UIBarButtonItem(title: "완료", style: .done, target: self, action: #selector(self.didCompleteButtonTouched))
     }
     
+    override func viewWillAppear(_ animated: Bool) {
+        super.viewWillAppear(animated)
+        self.buddyChoiceViewModel.viewWillAppear()
+    }
+    
     func configureBuddyList(by buddyList: [Buddy]) {
         self.buddyChoiceViewModel.didBuddyListLoaded(by: buddyList)
     }
@@ -138,7 +143,6 @@ final class BuddyChoiceViewController: UIViewController {
     
     @objc private func didNewBuddyButtonTouched(_ sender: UIButton) {
         let buddyCustomViewController = BuddyCustomViewController()
-        buddyCustomViewController.delegate = self
         self.navigationController?.pushViewController(buddyCustomViewController, animated: true)
     }
     
@@ -200,7 +204,6 @@ extension BuddyChoiceViewController: UICollectionViewDelegate {
             let edit = UIAction(title: NSLocalizedString("편집", comment: String()),
                                 image: UIImage(systemName: "pencil.circle")) { _ in
                 let buddyCustomViewController = BuddyCustomViewController()
-                buddyCustomViewController.delegate = self
                 buddyCustomViewController.configure(by: self.buddyChoiceViewModel[indexPath.item])
                 self.navigationController?.pushViewController(buddyCustomViewController, animated: true)
             }
@@ -210,18 +213,6 @@ extension BuddyChoiceViewController: UICollectionViewDelegate {
             }
             return UIMenu(title: "이 버디를", children: [edit, delete])
         })
-    }
-    
-}
-
-extension BuddyChoiceViewController: BuddyCustomDelegate {
-    
-    func didBuddyEditCompleted(_ buddy: Buddy) {
-        self.buddyChoiceViewModel.didBuddyEdited(buddy)
-    }
-    
-    func didBuddyAddCompleted(_ buddy: Buddy) {
-        self.buddyChoiceViewModel.didBuddyAdded(buddy)
     }
     
 }

--- a/WithBuddy/Presentation/BuddyCustom/ViewModel/BuddyCustomViewModel.swift
+++ b/WithBuddy/Presentation/BuddyCustom/ViewModel/BuddyCustomViewModel.swift
@@ -27,9 +27,14 @@ final class BuddyCustomViewModel {
     private var id: UUID?
     @Published private(set) var name: String = String()
     @Published private(set) var face: Face = Face(color: .purple, number: 1)
-    private(set) var addDoneSignal = PassthroughSubject<Buddy, Never>()
-    private(set) var editDoneSignal = PassthroughSubject<Buddy, Never>()
+    private(set) var addDoneSignal = PassthroughSubject<Void, Never>()
+    private(set) var editDoneSignal = PassthroughSubject<Void, Never>()
     private(set) var failSignal = PassthroughSubject<BuddyCustomError, Never>()
+    private let buddyUseCase: BuddyUseCase
+    
+    init(buddyUseCase: BuddyUseCase = BuddyUseCase()){
+        self.buddyUseCase = buddyUseCase
+    }
     
     func didBuddyInserted(_ buddy: Buddy) {
         self.id = buddy.id
@@ -61,12 +66,12 @@ final class BuddyCustomViewModel {
         if self.name.count < self.minNameLen {
             self.failSignal.send(BuddyCustomError.nameLength)
         } else {
-            var newBuddy = Buddy(id: UUID(), name: self.name, face: "\(self.face)")
             if let id = self.id {
-                newBuddy.id = id
-                self.editDoneSignal.send(newBuddy)
+                self.buddyUseCase.updateBuddy(Buddy(id: id, name: self.name, face: "\(self.face)"))
+                self.editDoneSignal.send()
             } else {
-                self.addDoneSignal.send(newBuddy)
+                self.buddyUseCase.insertBuddy(Buddy(id: UUID(), name: self.name, face: "\(self.face)"))
+                self.addDoneSignal.send()
             }
         }
     }

--- a/WithBuddy/Presentation/BuddyManage/View/BuddyManageViewController.swift
+++ b/WithBuddy/Presentation/BuddyManage/View/BuddyManageViewController.swift
@@ -31,6 +31,7 @@ final class BuddyManageViewController: UIViewController {
     
     override func viewWillAppear(_ animated: Bool) {
         super.viewWillAppear(animated)
+        self.buddyManageViewModel.viewWillAppear()
         self.title = "버디 관리"
     }
     
@@ -63,7 +64,6 @@ final class BuddyManageViewController: UIViewController {
         self.configureSearchView()
         self.configureButton()
         self.configureBuddyCollectionView()
-        self.buddyManageViewModel.didBuddyListLoaded()
     }
     
     private func configureSearchView() {
@@ -123,7 +123,6 @@ final class BuddyManageViewController: UIViewController {
     
     @objc private func didNewBuddyButtonTouched(_ sender: UIButton) {
         let buddyCustomViewController = BuddyCustomViewController()
-        buddyCustomViewController.delegate = self
         buddyCustomViewController.title = "버디 생성"
         self.navigationController?.pushViewController(buddyCustomViewController, animated: true)
     }
@@ -182,7 +181,6 @@ extension BuddyManageViewController: UICollectionViewDelegate {
             let edit = UIAction(title: NSLocalizedString("편집", comment: String()),
                                 image: UIImage(systemName: "pencil.circle")) { _ in
                 let buddyCustomViewController = BuddyCustomViewController()
-                buddyCustomViewController.delegate = self
                 buddyCustomViewController.title = "버디 편집"
                 buddyCustomViewController.configure(by: self.buddyManageViewModel[indexPath.item])
                 self.navigationController?.pushViewController(buddyCustomViewController, animated: true)
@@ -195,18 +193,6 @@ extension BuddyManageViewController: UICollectionViewDelegate {
         })
     }
 
-}
-
-extension BuddyManageViewController: BuddyCustomDelegate {
-    
-    func didBuddyEditCompleted(_ buddy: Buddy) {
-        self.buddyManageViewModel.buddyDidEdited(buddy)
-    }
-    
-    func didBuddyAddCompleted(_ buddy: Buddy) {
-        self.buddyManageViewModel.didBuddyAdded(buddy)
-    }
-    
 }
 
 extension BuddyManageViewController: UIGestureRecognizerDelegate {

--- a/WithBuddy/Presentation/BuddyManage/ViewModel/BuddyManageViewModel.swift
+++ b/WithBuddy/Presentation/BuddyManage/ViewModel/BuddyManageViewModel.swift
@@ -18,31 +18,22 @@ final class BuddyManageViewModel {
         return self.storedBuddyList[index]
     }
     
+    func viewWillAppear() {
+        self.didBuddyListLoaded()
+    }
+    
     func didBuddyDeleted(in idx: Int) {
         do {
             try self.buddyUseCase.deleteBuddy(storedBuddyList[idx])
-            self.storedBuddyList.remove(at: idx)
+            self.didBuddyListLoaded()
         } catch let error {
             guard let error = error as? BuddyChoiceError else { return }
             self.failSignal.send(error)
         }
     }
     
-    func didBuddyAdded(_ buddy: Buddy) {
-        self.buddyUseCase.insertBuddy(buddy)
-        self.storedBuddyList.append(buddy)
-    }
-    
-    func didBuddyListLoaded() {
+    private func didBuddyListLoaded() {
         self.storedBuddyList = self.buddyUseCase.fetchBuddy()
-    }
-    
-    func buddyDidEdited(_ buddy: Buddy) {
-        guard let idx = self.storedBuddyList.firstIndex(where: {
-            $0.id == buddy.id
-        }) else { return }
-        self.storedBuddyList[idx] = buddy
-        self.buddyUseCase.updateBuddy(buddy)
     }
     
 }

--- a/WithBuddy/Presentation/Chart/View/ChartViewController.swift
+++ b/WithBuddy/Presentation/Chart/View/ChartViewController.swift
@@ -190,23 +190,9 @@ final class ChartViewController: UIViewController {
     @objc private func didEditButtonTouched(_ sender: UITapGestureRecognizer) {
         guard let buddy = self.viewModel.selectedBuddy else { return }
         let buddyCustomViewController = BuddyCustomViewController()
-        buddyCustomViewController.delegate = self
         buddyCustomViewController.title = "버디 편집"
         buddyCustomViewController.configure(by: buddy)
         self.navigationController?.pushViewController(buddyCustomViewController, animated: true)
     }
 
-}
-
-extension ChartViewController: BuddyCustomDelegate {
-    
-    func didBuddyEditCompleted(_ buddy: Buddy) {
-        self.bubbleChartView.hideDescriptionView()
-        self.viewModel.didBuddyEdited(buddy)
-    }
-    
-    func didBuddyAddCompleted(_ buddy: Buddy) {
-        
-    }
-    
 }

--- a/WithBuddy/Presentation/Common/View/BuddyCustomView.swift
+++ b/WithBuddy/Presentation/Common/View/BuddyCustomView.swift
@@ -1,0 +1,146 @@
+//
+//  BuddyCustomView.swift
+//  WithBuddy
+//
+//  Created by 김두연 on 2021/12/01.
+//
+
+import UIKit
+
+class BuddyCustomView: UIScrollView {
+
+    private lazy var contentView = UIView()
+    
+    private(set) lazy var nameTextField = UITextField()
+    private lazy var lineView = UIView()
+    private(set) lazy var buddyImageView = UIImageView()
+    
+    private lazy var colorTitleLabel = BlackTitleLabel()
+    private(set) lazy var colorCollectionView = ColorCollectionView()
+    
+    private lazy var faceTitleLabel = BlackTitleLabel()
+    private(set) lazy var faceCollectionView = FaceCollectionView()
+    
+    override init(frame: CGRect) {
+        super.init(frame: frame)
+        self.configure()
+    }
+    
+    required init?(coder: NSCoder) {
+        super.init(coder: coder)
+    }
+    
+    override func touchesBegan(_ touches: Set<UITouch>, with event: UIEvent?) {
+        self.endEditing(true)
+    }
+    
+    func configure() {
+        self.configureContentView()
+        self.configureNameTextField()
+        self.configureLineView()
+        self.configureMyBuddyImageView()
+        self.configureColorTitleLabel()
+        self.configureColorCollectionView()
+        self.configureFaceTitleLabel()
+        self.configureFaceCollectionView()
+    }
+    
+    private func configureContentView() {
+        self.addSubview(self.contentView)
+        self.contentView.translatesAutoresizingMaskIntoConstraints = false
+        NSLayoutConstraint.activate([
+            self.contentView.topAnchor.constraint(equalTo: self.topAnchor),
+            self.contentView.bottomAnchor.constraint(equalTo: self.bottomAnchor),
+            self.contentView.leadingAnchor.constraint(equalTo: self.leadingAnchor),
+            self.contentView.trailingAnchor.constraint(equalTo: self.trailingAnchor),
+            self.contentView.widthAnchor.constraint(equalTo: self.widthAnchor)
+        ])
+    }
+    
+    private func configureNameTextField() {
+        self.contentView.addSubview(self.nameTextField)
+        if let color = UIColor.labelPurple {
+            self.nameTextField.attributedPlaceholder = NSAttributedString(string: "이름을 입력해주세요.", attributes: [NSAttributedString.Key.foregroundColor: color])
+        }
+        self.nameTextField.textAlignment = .center
+        
+        self.nameTextField.translatesAutoresizingMaskIntoConstraints = false
+        NSLayoutConstraint.activate([
+            self.nameTextField.topAnchor.constraint(equalTo: self.contentView.topAnchor, constant: 10),
+            self.nameTextField.centerXAnchor.constraint(equalTo: self.contentView.centerXAnchor)
+        ])
+    }
+    
+    private func configureLineView() {
+        self.contentView.addSubview(self.lineView)
+        self.lineView.backgroundColor = .labelPurple
+        
+        self.lineView.translatesAutoresizingMaskIntoConstraints = false
+        NSLayoutConstraint.activate([
+            self.lineView.topAnchor.constraint(equalTo: self.nameTextField.bottomAnchor, constant: 5),
+            self.lineView.leadingAnchor.constraint(equalTo: self.nameTextField.leadingAnchor),
+            self.lineView.trailingAnchor.constraint(equalTo: self.nameTextField.trailingAnchor),
+            self.lineView.heightAnchor.constraint(equalToConstant: 1)
+        ])
+    }
+    
+    private func configureMyBuddyImageView() {
+        self.contentView.addSubview(self.buddyImageView)
+        
+        self.buddyImageView.translatesAutoresizingMaskIntoConstraints = false
+        NSLayoutConstraint.activate([
+            self.buddyImageView.topAnchor.constraint(equalTo: self.lineView.bottomAnchor, constant: 10),
+            self.buddyImageView.centerXAnchor.constraint(equalTo: self.contentView.centerXAnchor),
+            self.buddyImageView.widthAnchor.constraint(equalToConstant: 250),
+            self.buddyImageView.heightAnchor.constraint(equalToConstant: 250)
+        ])
+    }
+    
+    private func configureColorTitleLabel() {
+        self.contentView.addSubview(self.colorTitleLabel)
+        self.colorTitleLabel.text = "색상"
+        
+        self.colorTitleLabel.translatesAutoresizingMaskIntoConstraints = false
+        NSLayoutConstraint.activate([
+            self.colorTitleLabel.topAnchor.constraint(equalTo: self.buddyImageView.bottomAnchor, constant: 20),
+            self.colorTitleLabel.leadingAnchor.constraint(equalTo: self.contentView.leadingAnchor, constant: 20)
+        ])
+    }
+    
+    private func configureColorCollectionView() {
+        self.contentView.addSubview(self.colorCollectionView)
+        
+        self.colorCollectionView.translatesAutoresizingMaskIntoConstraints = false
+        NSLayoutConstraint.activate([
+            self.colorCollectionView.topAnchor.constraint(equalTo: self.colorTitleLabel.bottomAnchor, constant: 10),
+            self.colorCollectionView.leadingAnchor.constraint(equalTo: self.contentView.leadingAnchor, constant: 20),
+            self.colorCollectionView.trailingAnchor.constraint(equalTo: self.contentView.trailingAnchor, constant: -20),
+            self.colorCollectionView.heightAnchor.constraint(equalTo: self.colorCollectionView.widthAnchor, multiplier: CGFloat(1.0/6.0))
+        ])
+    }
+    
+    private func configureFaceTitleLabel() {
+        self.contentView.addSubview(self.faceTitleLabel)
+        self.faceTitleLabel.text = "얼굴"
+        
+        self.faceTitleLabel.translatesAutoresizingMaskIntoConstraints = false
+        NSLayoutConstraint.activate([
+            self.faceTitleLabel.topAnchor.constraint(equalTo: self.colorCollectionView.bottomAnchor, constant: 20),
+            self.faceTitleLabel.leadingAnchor.constraint(equalTo: self.contentView.leadingAnchor, constant: 20)
+        ])
+    }
+    
+    private func configureFaceCollectionView() {
+        self.contentView.addSubview(self.faceCollectionView)
+        
+        self.faceCollectionView.translatesAutoresizingMaskIntoConstraints = false
+        NSLayoutConstraint.activate([
+            self.faceCollectionView.topAnchor.constraint(equalTo: self.faceTitleLabel.bottomAnchor, constant: 10),
+            self.faceCollectionView.leadingAnchor.constraint(equalTo: self.contentView.leadingAnchor, constant: 20),
+            self.faceCollectionView.trailingAnchor.constraint(equalTo: self.contentView.trailingAnchor, constant: -20),
+            self.faceCollectionView.heightAnchor.constraint(equalTo: self.faceCollectionView.widthAnchor, multiplier: 3.0/5.0),
+            self.faceCollectionView.bottomAnchor.constraint(equalTo: self.contentView.bottomAnchor)
+        ])
+    }
+    
+}

--- a/WithBuddy/Presentation/Common/View/ColorCollectionView.swift
+++ b/WithBuddy/Presentation/Common/View/ColorCollectionView.swift
@@ -1,0 +1,43 @@
+//
+//  ColorCollectionView.swift
+//  WithBuddy
+//
+//  Created by 김두연 on 2021/12/01.
+//
+
+import UIKit
+
+class ColorCollectionView: UICollectionView {
+
+    init() {
+        super.init(frame: .zero, collectionViewLayout: UICollectionViewFlowLayout())
+        self.configure()
+    }
+    
+    required init?(coder: NSCoder) {
+        super.init(coder: coder)
+        self.configure()
+    }
+    
+    private func configure() {
+        self.register(ImageCollectionViewCell.self, forCellWithReuseIdentifier: ImageCollectionViewCell.identifier)
+        self.configureLayout()
+    }
+    
+    private func configureLayout() {
+        let itemSize = NSCollectionLayoutSize(
+            widthDimension: .fractionalWidth(1.0/6.0),
+            heightDimension: .fractionalHeight(1.0)
+        )
+        let item = NSCollectionLayoutItem(layoutSize: itemSize)
+        let groupSize = NSCollectionLayoutSize(
+            widthDimension: .fractionalWidth(1.0),
+            heightDimension: .fractionalHeight(1.0)
+        )
+        let group = NSCollectionLayoutGroup.horizontal(layoutSize: groupSize, subitems: [item])
+        let section = NSCollectionLayoutSection(group: group)
+        
+        self.collectionViewLayout = UICollectionViewCompositionalLayout(section: section)
+    }
+
+}

--- a/WithBuddy/Presentation/Common/View/FaceCollectionView.swift
+++ b/WithBuddy/Presentation/Common/View/FaceCollectionView.swift
@@ -1,0 +1,43 @@
+//
+//  FaceCollectionView.swift
+//  WithBuddy
+//
+//  Created by 김두연 on 2021/12/01.
+//
+
+import UIKit
+
+class FaceCollectionView: UICollectionView {
+
+    init() {
+        super.init(frame: .zero, collectionViewLayout: UICollectionViewFlowLayout())
+        self.configure()
+    }
+    
+    required init?(coder: NSCoder) {
+        super.init(coder: coder)
+        self.configure()
+    }
+    
+    private func configure() {
+        self.register(ImageCollectionViewCell.self, forCellWithReuseIdentifier: ImageCollectionViewCell.identifier)
+        self.configureLayout()
+    }
+    
+    private func configureLayout() {
+        let itemSize = NSCollectionLayoutSize(
+            widthDimension: .fractionalWidth(1.0/5.0),
+            heightDimension: .fractionalHeight(1.0)
+        )
+        let item = NSCollectionLayoutItem(layoutSize: itemSize)
+        let groupSize = NSCollectionLayoutSize(
+            widthDimension: .fractionalWidth(1.0),
+            heightDimension: .fractionalHeight(1.0/3.0)
+        )
+        let group = NSCollectionLayoutGroup.horizontal(layoutSize: groupSize, subitems: [item])
+        let section = NSCollectionLayoutSection(group: group)
+        
+        self.collectionViewLayout = UICollectionViewCompositionalLayout(section: section)
+    }
+
+}

--- a/WithBuddy/Presentation/Setting/View/SettingViewController.swift
+++ b/WithBuddy/Presentation/Setting/View/SettingViewController.swift
@@ -26,6 +26,11 @@ final class SettingViewController: UIViewController {
         self.bind()
     }
     
+    override func viewWillAppear(_ animated: Bool) {
+        super.viewWillAppear(animated)
+        self.settingViewModel.viewWillAppear()
+    }
+    
     private func bind() {
         self.settingViewModel.deleteSignal
             .receive(on: DispatchQueue.main)
@@ -55,7 +60,6 @@ final class SettingViewController: UIViewController {
         self.configureUserImage()
         self.configureUserName()
         self.configureModifyButton()
-        self.settingViewModel.reloadMyBuddy()
     }
     
     private func configureUserImage() {
@@ -103,12 +107,9 @@ final class SettingViewController: UIViewController {
     
     @objc private func didProfileEditButtonTouched(_ sender: UIButton) {
         self.modifyButton.animateButtonTap(scale: 0.9)
-        guard let myBuddy = self.settingViewModel.myBuddy else { return }
-        let buddyCustomViewController = BuddyCustomViewController()
-        buddyCustomViewController.delegate = self
-        buddyCustomViewController.configure(by: myBuddy)
-        buddyCustomViewController.title = "프로필 수정"
-        self.navigationController?.pushViewController(buddyCustomViewController, animated: true)
+        let userEditViewController = UserEditViewController()
+        userEditViewController.title = "프로필 수정"
+        self.navigationController?.pushViewController(userEditViewController, animated: true)
     }
     
     private func configureButtons() {
@@ -173,20 +174,6 @@ final class SettingViewController: UIViewController {
         guard let wikiURL = URL(string: "https://github.com/boostcampwm-2021/iOS08-WithBuddy/wiki") else { return }
         let developSafariView: SFSafariViewController = SFSafariViewController(url: wikiURL)
         self.present(developSafariView, animated: true, completion: nil)
-    }
-    
-}
-
-extension SettingViewController: BuddyCustomDelegate {
-    
-    func didBuddyAddCompleted(_ buddy: Buddy) {
-        self.settingViewModel.didMyBuddyChanged(buddy: buddy)
-        self.settingViewModel.reloadMyBuddy()
-    }
-    
-    func didBuddyEditCompleted(_ buddy: Buddy) {
-        self.settingViewModel.didMyBuddyChanged(buddy: buddy)
-        self.settingViewModel.reloadMyBuddy()
     }
     
 }

--- a/WithBuddy/Presentation/Setting/ViewModel/SettingViewModel.swift
+++ b/WithBuddy/Presentation/Setting/ViewModel/SettingViewModel.swift
@@ -25,6 +25,10 @@ final class SettingViewModel {
         self.gatheringUseCase = gatheringUseCase
     }
     
+    func viewWillAppear() {
+        self.myBuddy = self.userUseCase.fetchUser()
+    }
+    
     func didGatheringResetTouched() {
         self.gatheringUseCase.deleteAllGathering()
             .receive(on: DispatchQueue.main)
@@ -42,10 +46,6 @@ final class SettingViewModel {
     
     func didMyBuddyChanged(buddy: Buddy) {
         self.userUseCase.createUser(buddy: buddy)
-    }
-    
-    func reloadMyBuddy() {
-        self.myBuddy = self.userUseCase.fetchUser()
     }
     
 }

--- a/WithBuddy/Presentation/UserCreate/View/UserCreateViewController.swift
+++ b/WithBuddy/Presentation/UserCreate/View/UserCreateViewController.swift
@@ -72,12 +72,12 @@ final class UserCreateViewController: UIViewController {
         self.userCreateViewModel.editStartSignal
             .receive(on: DispatchQueue.main)
             .sink { [weak self] buddy in
-                let buddyCustomViewController = BuddyCustomViewController()
-                buddyCustomViewController.delegate = self
+                let userCustomViewController = UserCustomViewController()
+                userCustomViewController.delegate = self
                 if let buddy = buddy {
-                    buddyCustomViewController.configure(by: buddy)
+                    userCustomViewController.configure(by: buddy)
                 }
-                self?.navigationController?.pushViewController(buddyCustomViewController, animated: true)
+                self?.navigationController?.pushViewController(userCustomViewController, animated: true)
             }
             .store(in: &self.cancellables)
         
@@ -195,13 +195,9 @@ final class UserCreateViewController: UIViewController {
 
 }
 
-extension UserCreateViewController: BuddyCustomDelegate {
+extension UserCreateViewController: UserCustomDelegate {
     
-    func didBuddyEditCompleted(_ buddy: Buddy) {
-        self.userCreateViewModel.didUserChanged(buddy: buddy)
-    }
-    
-    func didBuddyAddCompleted(_ buddy: Buddy) {
+    func didDoneTouched(_ buddy: Buddy) {
         self.userCreateViewModel.didUserChanged(buddy: buddy)
     }
     

--- a/WithBuddy/Presentation/UserCustom/View/UserCustomViewController.swift
+++ b/WithBuddy/Presentation/UserCustom/View/UserCustomViewController.swift
@@ -1,0 +1,19 @@
+//
+//  UserCustomViewController.swift
+//  WithBuddy
+//
+//  Created by 김두연 on 2021/12/01.
+//
+
+import UIKit
+
+class UserCustomViewController: UIViewController {
+
+    override func viewDidLoad() {
+        super.viewDidLoad()
+
+        // Do any additional setup after loading the view.
+    }
+    
+
+}

--- a/WithBuddy/Presentation/UserCustom/View/UserCustomViewController.swift
+++ b/WithBuddy/Presentation/UserCustom/View/UserCustomViewController.swift
@@ -6,14 +6,169 @@
 //
 
 import UIKit
+import Combine
 
-class UserCustomViewController: UIViewController {
-
-    override func viewDidLoad() {
-        super.viewDidLoad()
-
-        // Do any additional setup after loading the view.
+final class UserCustomViewController: UIViewController {
+    
+    private lazy var buddyCustomView = BuddyCustomView()
+    private lazy var colorDataSource = UICollectionViewDiffableDataSource<Int, CheckableInfo>(collectionView: self.buddyCustomView.colorCollectionView) { (collectionView: UICollectionView, indexPath: IndexPath, itemIdentifier: CheckableInfo) -> UICollectionViewCell? in
+        guard let cell = collectionView.dequeueReusableCell(withReuseIdentifier: ImageCollectionViewCell.identifier, for: indexPath) as? ImageCollectionViewCell else { preconditionFailure() }
+        cell.update(image: UIImage(named: itemIdentifier.engDescription), check: itemIdentifier.check)
+        return cell
+    }
+    private lazy var faceDataSource = UICollectionViewDiffableDataSource<Int, CheckableInfo>(collectionView: self.buddyCustomView.faceCollectionView) { (collectionView: UICollectionView, indexPath: IndexPath, itemIdentifier: CheckableInfo) -> UICollectionViewCell? in
+        guard let cell = collectionView.dequeueReusableCell(withReuseIdentifier: ImageCollectionViewCell.identifier, for: indexPath) as? ImageCollectionViewCell else { preconditionFailure() }
+        cell.update(image: UIImage(named: itemIdentifier.engDescription), check: itemIdentifier.check)
+        return cell
     }
     
+    private var userCustomViewModel = UserCustomViewModel()
+    private var cancellables: Set<AnyCancellable> = []
+    weak var delegate: UserCustomDelegate?
+    
+    override func viewDidLoad() {
+        super.viewDidLoad()
+        self.view.backgroundColor = .backgroundPurple
+        self.navigationItem.rightBarButtonItem = UIBarButtonItem(title: "완료", style: .done, target: self, action: #selector(self.didDoneTouched))
+        self.configure()
+        self.bind()
+    }
+    
+    override func viewDidAppear(_ animated: Bool) {
+        super.viewDidAppear(animated)
+        NotificationCenter.default.addObserver(self, selector: #selector(didTextChanged), name: UITextField.textDidChangeNotification, object: nil)
+    }
 
+    override func viewDidDisappear(_ animated: Bool) {
+        super.viewDidDisappear(animated)
+        NotificationCenter.default.removeObserver(self, name: UITextField.textDidChangeNotification, object: nil)
+    }
+
+    @objc private func didTextChanged() {
+        if let text = self.buddyCustomView.nameTextField.text {
+            if text.count > 10 {
+                let index = text.index(text.startIndex, offsetBy: 10)
+                self.buddyCustomView.nameTextField.text = String(text[..<index])
+                self.buddyCustomView.nameTextField.resignFirstResponder()
+            }
+        }
+    }
+    
+    func configure(by buddy: Buddy) {
+        self.userCustomViewModel.didBuddyInserted(buddy)
+    }
+    
+    private func bind() {
+        self.userCustomViewModel.$face
+            .receive(on: DispatchQueue.main)
+            .sink { [weak self] face in
+                var colorSnapshot = NSDiffableDataSourceSnapshot<Int, CheckableInfo>()
+                colorSnapshot.appendSections([0])
+                colorSnapshot.appendItems(FaceColor.allCases.map({
+                    CheckableInfo(engDescription: $0.description, korDescription: $0.description, check: $0 == face.color)
+                }))
+                self?.colorDataSource.apply(colorSnapshot, animatingDifferences: true)
+                
+                var faceSnapshot = NSDiffableDataSourceSnapshot<Int, CheckableInfo>()
+                faceSnapshot.appendSections([0])
+                faceSnapshot.appendItems((Int.minFaceNum...Int.maxFaceNum).map({
+                    CheckableInfo(engDescription: "\(face.color)\($0)", korDescription: "\(face.color)\($0)", check: $0 == face.number)
+                }))
+                self?.faceDataSource.apply(faceSnapshot, animatingDifferences: true)
+                
+                self?.buddyCustomView.buddyImageView.image = UIImage(named: "\(face)")
+            }
+            .store(in: &self.cancellables)
+        
+        self.userCustomViewModel.$name
+            .receive(on: DispatchQueue.main)
+            .sink { [weak self] text in
+                self?.buddyCustomView.nameTextField.text = text
+            }
+            .store(in: &self.cancellables)
+        
+        self.userCustomViewModel.createDoneSignal
+            .receive(on: DispatchQueue.main)
+            .sink { [weak self] buddy in
+                self?.delegate?.didDoneTouched(buddy)
+                self?.navigationController?.popViewController(animated: true)
+            }
+            .store(in: &self.cancellables)
+        
+        self.userCustomViewModel.failSignal
+            .receive(on: DispatchQueue.main)
+            .sink { [weak self] result in
+                self?.alertError(result)
+            }
+            .store(in: &self.cancellables)
+    }
+    
+    private func configure() {
+        self.view.addSubview(self.buddyCustomView)
+        
+        buddyCustomView.nameTextField.delegate = self
+        buddyCustomView.colorCollectionView.delegate = self
+        buddyCustomView.faceCollectionView.delegate = self
+        self.buddyCustomView.translatesAutoresizingMaskIntoConstraints = false
+        NSLayoutConstraint.activate([
+            self.buddyCustomView.topAnchor.constraint(equalTo: self.view.safeAreaLayoutGuide.topAnchor),
+            self.buddyCustomView.bottomAnchor.constraint(equalTo: self.view.safeAreaLayoutGuide.bottomAnchor),
+            self.buddyCustomView.leadingAnchor.constraint(equalTo: self.view.safeAreaLayoutGuide.leadingAnchor),
+            self.buddyCustomView.trailingAnchor.constraint(equalTo: self.view.safeAreaLayoutGuide.trailingAnchor)
+        ])
+        
+    }
+    
+    private func alertError(_ error: BuddyCustomError) {
+        let alert = UIAlertController(title: "캐릭터 설정 실패", message: error.errorDescription, preferredStyle: UIAlertController.Style.alert)
+        let action = UIAlertAction(title: "OK", style: .default, handler: { _ in })
+        alert.addAction(action)
+        self.present(alert, animated: true, completion: nil)
+    }
+    
+    @objc private func didDoneTouched() {
+        self.userCustomViewModel.didDoneTouched()
+    }
+    
+}
+
+extension UserCustomViewController: UITextFieldDelegate {
+    
+    func textFieldShouldReturn(_ textField: UITextField) -> Bool {
+        textField.resignFirstResponder()
+        return true
+    }
+    
+    func textFieldDidChangeSelection(_ textField: UITextField) {
+        guard let text = textField.text else { return }
+        self.userCustomViewModel.didNameChaged(name: text)
+    }
+    
+    func textField(_ textField: UITextField, shouldChangeCharactersIn range: NSRange, replacementString string: String) -> Bool {
+        guard let text = textField.text else { return false }
+        if text.count >= 10 && range.length == 0 && range.location < 10 {
+            return false
+        }
+        return true
+    }
+
+}
+
+extension UserCustomViewController: UICollectionViewDelegate {
+    
+    func collectionView(_ collectionView: UICollectionView, didSelectItemAt indexPath: IndexPath) {
+        self.view.endEditing(true)
+        if collectionView == self.buddyCustomView.colorCollectionView {
+            self.userCustomViewModel.didColorChosend(in: indexPath.item)
+        } else {
+            self.userCustomViewModel.didFaceChosen(in: indexPath.item)
+        }
+    }
+    
+}
+
+protocol UserCustomDelegate: AnyObject {
+    
+    func didDoneTouched(_ buddy: Buddy)
+    
 }

--- a/WithBuddy/Presentation/UserCustom/ViewModel/UserCustomViewModel.swift
+++ b/WithBuddy/Presentation/UserCustom/ViewModel/UserCustomViewModel.swift
@@ -1,0 +1,52 @@
+//
+//  UserCustomViewModel.swift
+//  WithBuddy
+//
+//  Created by 김두연 on 2021/12/01.
+//
+
+import Foundation
+import Combine
+
+final class UserCustomViewModel {
+    
+    @Published private(set) var name: String = ""
+    @Published private(set) var face: Face = Face(color: .purple, number: 1)
+    private(set) var createDoneSignal = PassthroughSubject<Buddy, Never>()
+    private(set) var failSignal = PassthroughSubject<BuddyCustomError, Never>()
+    
+    func didBuddyInserted(_ buddy: Buddy) {
+        self.name = buddy.name
+        
+        let faceColor = buddy.face.filter({ $0.isLetter })
+        for color in FaceColor.allCases where color.description == faceColor {
+            self.face.color = color
+        }
+        
+        if let faceNumber = Int(buddy.face.filter({ $0.isNumber })) {
+            self.face.number = faceNumber
+        }
+    }
+    
+    func didColorChosend(in idx: Int) {
+        self.face.color = FaceColor.allCases[idx]
+    }
+    
+    func didFaceChosen(in idx: Int) {
+        self.face.number = idx + 1
+    }
+    
+    func didNameChaged(name: String) {
+        self.name = name
+    }
+    
+    func didDoneTouched() {
+        if self.name.count < 2 {
+            self.failSignal.send(BuddyCustomError.nameLength)
+        } else {
+            let newBuddy = Buddy(id: UUID(), name: self.name, face: "\(self.face)")
+            self.createDoneSignal.send(newBuddy)
+        }
+    }
+    
+}

--- a/WithBuddy/Presentation/UserEdit/View/UserEditViewController.swift
+++ b/WithBuddy/Presentation/UserEdit/View/UserEditViewController.swift
@@ -161,4 +161,3 @@ extension UserEditViewController: UICollectionViewDelegate {
     }
     
 }
-

--- a/WithBuddy/Presentation/UserEdit/View/UserEditViewController.swift
+++ b/WithBuddy/Presentation/UserEdit/View/UserEditViewController.swift
@@ -1,0 +1,164 @@
+//
+//  UserEditViewController.swift
+//  WithBuddy
+//
+//  Created by 김두연 on 2021/12/01.
+//
+
+import UIKit
+import Combine
+
+final class UserEditViewController: UIViewController {
+
+    private lazy var buddyCustomView = BuddyCustomView()
+    private lazy var colorDataSource = UICollectionViewDiffableDataSource<Int, CheckableInfo>(collectionView: self.buddyCustomView.colorCollectionView) { (collectionView: UICollectionView, indexPath: IndexPath, itemIdentifier: CheckableInfo) -> UICollectionViewCell? in
+        guard let cell = collectionView.dequeueReusableCell(withReuseIdentifier: ImageCollectionViewCell.identifier, for: indexPath) as? ImageCollectionViewCell else { preconditionFailure() }
+        cell.update(image: UIImage(named: itemIdentifier.engDescription), check: itemIdentifier.check)
+        return cell
+    }
+    private lazy var faceDataSource = UICollectionViewDiffableDataSource<Int, CheckableInfo>(collectionView: self.buddyCustomView.faceCollectionView) { (collectionView: UICollectionView, indexPath: IndexPath, itemIdentifier: CheckableInfo) -> UICollectionViewCell? in
+        guard let cell = collectionView.dequeueReusableCell(withReuseIdentifier: ImageCollectionViewCell.identifier, for: indexPath) as? ImageCollectionViewCell else { preconditionFailure() }
+        cell.update(image: UIImage(named: itemIdentifier.engDescription), check: itemIdentifier.check)
+        return cell
+    }
+    
+    private var userEditViewModel = UserEditViewModel()
+    private var cancellables: Set<AnyCancellable> = []
+    
+    override func viewDidLoad() {
+        super.viewDidLoad()
+        self.view.backgroundColor = .backgroundPurple
+        self.navigationItem.rightBarButtonItem = UIBarButtonItem(title: "완료", style: .done, target: self, action: #selector(self.didDoneTouched))
+        self.configure()
+        self.bind()
+        self.userEditViewModel.viewDidLoad()
+    }
+    
+    override func viewDidAppear(_ animated: Bool) {
+        super.viewDidAppear(animated)
+        NotificationCenter.default.addObserver(self, selector: #selector(didTextChanged), name: UITextField.textDidChangeNotification, object: nil)
+    }
+
+    override func viewDidDisappear(_ animated: Bool) {
+        super.viewDidDisappear(animated)
+        NotificationCenter.default.removeObserver(self, name: UITextField.textDidChangeNotification, object: nil)
+    }
+
+    @objc private func didTextChanged() {
+        if let text = self.buddyCustomView.nameTextField.text {
+            if text.count > 10 {
+                let index = text.index(text.startIndex, offsetBy: 10)
+                self.buddyCustomView.nameTextField.text = String(text[..<index])
+                self.buddyCustomView.nameTextField.resignFirstResponder()
+            }
+        }
+    }
+    
+    private func bind() {
+        self.userEditViewModel.$face
+            .receive(on: DispatchQueue.main)
+            .sink { [weak self] face in
+                var colorSnapshot = NSDiffableDataSourceSnapshot<Int, CheckableInfo>()
+                colorSnapshot.appendSections([0])
+                colorSnapshot.appendItems(FaceColor.allCases.map({
+                    CheckableInfo(engDescription: $0.description, korDescription: $0.description, check: $0 == face.color)
+                }))
+                self?.colorDataSource.apply(colorSnapshot, animatingDifferences: true)
+                
+                var faceSnapshot = NSDiffableDataSourceSnapshot<Int, CheckableInfo>()
+                faceSnapshot.appendSections([0])
+                faceSnapshot.appendItems((Int.minFaceNum...Int.maxFaceNum).map({
+                    CheckableInfo(engDescription: "\(face.color)\($0)", korDescription: "\(face.color)\($0)", check: $0 == face.number)
+                }))
+                self?.faceDataSource.apply(faceSnapshot, animatingDifferences: true)
+                
+                self?.buddyCustomView.buddyImageView.image = UIImage(named: "\(face)")
+            }
+            .store(in: &self.cancellables)
+        
+        self.userEditViewModel.$name
+            .receive(on: DispatchQueue.main)
+            .sink { [weak self] text in
+                self?.buddyCustomView.nameTextField.text = text
+            }
+            .store(in: &self.cancellables)
+        
+        self.userEditViewModel.editDoneSignal
+            .receive(on: DispatchQueue.main)
+            .sink { [weak self] in
+                self?.navigationController?.popViewController(animated: true)
+            }
+            .store(in: &self.cancellables)
+        
+        self.userEditViewModel.failSignal
+            .receive(on: DispatchQueue.main)
+            .sink { [weak self] result in
+                self?.alertError(result)
+            }
+            .store(in: &self.cancellables)
+    }
+    
+    private func configure() {
+        self.view.addSubview(self.buddyCustomView)
+        
+        buddyCustomView.nameTextField.delegate = self
+        buddyCustomView.colorCollectionView.delegate = self
+        buddyCustomView.faceCollectionView.delegate = self
+        self.buddyCustomView.translatesAutoresizingMaskIntoConstraints = false
+        NSLayoutConstraint.activate([
+            self.buddyCustomView.topAnchor.constraint(equalTo: self.view.safeAreaLayoutGuide.topAnchor),
+            self.buddyCustomView.bottomAnchor.constraint(equalTo: self.view.safeAreaLayoutGuide.bottomAnchor),
+            self.buddyCustomView.leadingAnchor.constraint(equalTo: self.view.safeAreaLayoutGuide.leadingAnchor),
+            self.buddyCustomView.trailingAnchor.constraint(equalTo: self.view.safeAreaLayoutGuide.trailingAnchor)
+        ])
+        
+    }
+    
+    private func alertError(_ error: BuddyCustomError) {
+        let alert = UIAlertController(title: "캐릭터 설정 실패", message: error.errorDescription, preferredStyle: UIAlertController.Style.alert)
+        let action = UIAlertAction(title: "OK", style: .default, handler: { _ in })
+        alert.addAction(action)
+        self.present(alert, animated: true, completion: nil)
+    }
+    
+    @objc private func didDoneTouched() {
+        self.userEditViewModel.didDoneTouched()
+    }
+    
+}
+
+extension UserEditViewController: UITextFieldDelegate {
+    
+    func textFieldShouldReturn(_ textField: UITextField) -> Bool {
+        textField.resignFirstResponder()
+        return true
+    }
+    
+    func textFieldDidChangeSelection(_ textField: UITextField) {
+        guard let text = textField.text else { return }
+        self.userEditViewModel.didNameChaged(name: text)
+    }
+    
+    func textField(_ textField: UITextField, shouldChangeCharactersIn range: NSRange, replacementString string: String) -> Bool {
+        guard let text = textField.text else { return false }
+        if text.count >= 10 && range.length == 0 && range.location < 10 {
+            return false
+        }
+        return true
+    }
+
+}
+
+extension UserEditViewController: UICollectionViewDelegate {
+    
+    func collectionView(_ collectionView: UICollectionView, didSelectItemAt indexPath: IndexPath) {
+        self.view.endEditing(true)
+        if collectionView == self.buddyCustomView.colorCollectionView {
+            self.userEditViewModel.didColorChosend(in: indexPath.item)
+        } else {
+            self.userEditViewModel.didFaceChosen(in: indexPath.item)
+        }
+    }
+    
+}
+

--- a/WithBuddy/Presentation/UserEdit/ViewModel/UserEditViewModel.swift
+++ b/WithBuddy/Presentation/UserEdit/ViewModel/UserEditViewModel.swift
@@ -1,0 +1,63 @@
+//
+//  UserEditViewModel.swift
+//  WithBuddy
+//
+//  Created by 김두연 on 2021/12/01.
+//
+
+import Foundation
+import Combine
+
+final class UserEditViewModel {
+    
+    @Published private(set) var name: String = ""
+    @Published private(set) var face: Face = Face(color: .purple, number: 1)
+    private(set) var editDoneSignal = PassthroughSubject<Void, Never>()
+    private(set) var failSignal = PassthroughSubject<BuddyCustomError, Never>()
+    private let userUseCase: UserUseCase
+    
+    init(userUseCase: UserUseCase = UserUseCase()){
+        self.userUseCase = userUseCase
+    }
+    
+    func viewDidLoad() {
+        guard let user = self.userUseCase.fetchUser() else { return }
+        self.didUserLoaded(user)
+    }
+    
+    private func didUserLoaded(_ user: Buddy) {
+        self.name = user.name
+        
+        let faceColor = user.face.filter({ $0.isLetter })
+        for color in FaceColor.allCases where color.description == faceColor {
+            self.face.color = color
+        }
+        
+        if let faceNumber = Int(user.face.filter({ $0.isNumber })) {
+            self.face.number = faceNumber
+        }
+    }
+    
+    func didColorChosend(in idx: Int) {
+        self.face.color = FaceColor.allCases[idx]
+    }
+    
+    func didFaceChosen(in idx: Int) {
+        self.face.number = idx + 1
+    }
+    
+    func didNameChaged(name: String) {
+        self.name = name
+    }
+    
+    func didDoneTouched() {
+        if self.name.count < 2 {
+            self.failSignal.send(BuddyCustomError.nameLength)
+        } else {
+            let editedUser = Buddy(id: UUID(), name: self.name, face: "\(self.face)")
+            self.userUseCase.createUser(buddy: editedUser)
+            self.editDoneSignal.send()
+        }
+    }
+    
+}


### PR DESCRIPTION
## 💡 이슈 번호

#281

<br/>

## 📚 작업 내역

- 일단 공통 뷰 분리하고 뷰컨트롤러 구분해 봤는데... 시간이 없어서 몇몇 부분은 구조가 조금 미흡하긴 하지만 분리를 해놨습니다.
- UserCustom -> 처음에 유저 생성할때 사용
- UserEdit -> Setting에서 유저 수정할때
- BuddyCustom -> 이게 조금 아쉬운데.. 우선 버디 생성, 수정할때 다 쓰입니다. 시간이 애매해서 이정도로 분리해봤어요 🥲

