### PR TITLE
(#293) iOS13, 14 View 문제해결

### DIFF
--- a/WithBuddy/Presentation/Calendar/View/WBCalendarCollectionView.swift
+++ b/WithBuddy/Presentation/Calendar/View/WBCalendarCollectionView.swift
@@ -22,6 +22,7 @@ final class WBCalendarCollectionView: UICollectionView {
     private func configure() {
         self.register(WBCalendarViewCell.self, forCellWithReuseIdentifier: WBCalendarViewCell.identifier)
         self.configureLayout()
+        self.backgroundColor = .clear
     }
     
     private func configureLayout() {

--- a/WithBuddy/Presentation/Register/View/RegisterViewController.swift
+++ b/WithBuddy/Presentation/Register/View/RegisterViewController.swift
@@ -243,11 +243,13 @@ final class RegisterViewController: UIViewController {
         self.datePicker.locale = Locale(identifier: "ko-KR")
         self.datePicker.timeZone = .autoupdatingCurrent
         self.datePicker.addTarget(self, action: #selector(self.didDateChanged), for: .valueChanged)
+        self.datePicker.contentHorizontalAlignment = .leading
         
         self.datePicker.translatesAutoresizingMaskIntoConstraints = false
         NSLayoutConstraint.activate([
             self.datePicker.topAnchor.constraint(equalTo: self.dateTitleLabel.bottomAnchor, constant: .innerPartInset),
-            self.datePicker.leadingAnchor.constraint(equalTo: self.contentView.leadingAnchor, constant: .plusInset)
+            self.datePicker.leadingAnchor.constraint(equalTo: self.contentView.leadingAnchor, constant: .plusInset),
+            self.datePicker.trailingAnchor.constraint(equalTo: self.contentView.trailingAnchor)
         ])
     }
     

--- a/WithBuddy/Presentation/UserCreate/View/UserCreateViewController.swift
+++ b/WithBuddy/Presentation/UserCreate/View/UserCreateViewController.swift
@@ -28,6 +28,16 @@ final class UserCreateViewController: UIViewController {
         self.bind()
     }
     
+    override func viewWillAppear(_ animated: Bool) {
+        super.viewWillAppear(animated)
+        self.navigationController?.setNavigationBarHidden(true, animated: animated)
+    }
+    
+    override func viewWillDisappear(_ animated: Bool) {
+        super.viewWillDisappear(animated)
+        self.navigationController?.setNavigationBarHidden(false, animated: animated)
+    }
+    
     override func viewDidAppear(_ animated: Bool) {
         super.viewDidAppear(animated)
         self.loadingView.addFaces()


### PR DESCRIPTION
## 💡 이슈 번호

#293 

<br/>

## 📚 작업 내역

- ios 13, 14에서 view가 깨지는 문제를 해결했습니다.
- 일정화면에서 일부 cell 뒤에 검정색 화면이 보이는 문제 해결
- datePicker 위치문제 해결
- navigation bar가 처음부터 등장하는 문제해결

